### PR TITLE
Made the reference to oripa.ini portable.

### DIFF
--- a/src/main/java/oripa/ORIPA.java
+++ b/src/main/java/oripa/ORIPA.java
@@ -22,7 +22,7 @@ import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.util.Locale;
 import java.util.ResourceBundle;
-
+import java.io.File;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
@@ -57,7 +57,7 @@ public class ORIPA {
     ;
 //    public static FoldabilityCheckFrame checkFrame;
 
-	public static String iniFilePath = System.getProperty("user.home") + "\\oripa.ini";
+	public static String iniFilePath = System.getProperty("user.home") + File.separator + "oripa.ini";
 
 	
 	private static final String resourcePackage = "oripa.resource";


### PR DESCRIPTION
Changed the file separator used for constructing the path to oripa.ini
from "\" to File.separator so that the code is portable.
