### PR TITLE
Fix deletion of short lines

### DIFF
--- a/src/main/java/oripa/value/CalculationResource.java
+++ b/src/main/java/oripa/value/CalculationResource.java
@@ -2,6 +2,6 @@ package oripa.value;
 
 public class CalculationResource {
 
-	public static final double POINT_EPS = 1.0;
+	public static final double POINT_EPS = 0.00001;
 	public static final double CLOSE_THRESHOLD = 10.0;
 }


### PR DESCRIPTION
When working with more complex cps, oripa sometimes deleted lines that were smaller than 1 unit (the default paper is 400 x 400). This should now be fixed