### PR TITLE
Bumb log4j-slf4j18-impl dependency to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.5.1</version>
+			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j18-impl</artifactId>
-			<version>2.12.1</version>
+			<version>2.16.0</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
This should fix the errors stalling #166 , other dependencies could be updated as well though.