### PR TITLE
Enable pasting without snap.

### DIFF
--- a/src/main/java/oripa/gui/presenter/creasepattern/copypaste/PasteAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/copypaste/PasteAction.java
@@ -73,6 +73,10 @@ public class PasteAction extends AbstractGraphicMouseAction {
 
 		}
 
+		if (closeVertex == null) {
+			closeVertex = viewContext.getLogicalMousePoint();
+		}
+
 		paintContext.setCandidateVertexToPick(closeVertex);
 
 		return closeVertex;


### PR DESCRIPTION
If the mouse point is far from any vertices, user can paste at the place where the mouse point is.