### PR TITLE
Change jpackage input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 					</execution>
 				</executions>
 				<configuration>
-x					<descriptorRefs>
+					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<archive>

--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,15 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>com.google.code.gson</groupId>
-		    <artifactId>gson</artifactId>
-		    <version>2.8.9</version>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.9</version>
 		</dependency>
 
 		<dependency>
-		    <groupId>commons-cli</groupId>
-		    <artifactId>commons-cli</artifactId>
-		    <version>1.5.0</version>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.5.0</version>
 		</dependency>
 
 	</dependencies>
@@ -105,7 +105,7 @@
 						<!-- Windows only. It causes error on other OS. -->
 						<!-- <windirchooser>true</windirchooser> -->
 
-						<input>${project.build.directory}</input>
+						<input>${project.build.directory}/jars</input>
 						<mainjar>${project.artifactId}-${project.version}.jar</mainjar>
 						<mainclass>oripa.ORIPA</mainclass>
 					</configuration>
@@ -141,7 +141,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<descriptorRefs>
+x					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<archive>
@@ -155,6 +155,34 @@
 					</archive>
 					<appendAssemblyId>false</appendAssemblyId>
 				</configuration>
+			</plugin>
+
+			<!-- copy jar for jpackage -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<id>copy-artifact</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>${project.artifactId}</artifactId>
+									<version>${project.version}</version>
+									<type>${project.packaging}</type>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${project.build.directory}/jars</outputDirectory>
+							<overWriteIfNewer>true</overWriteIfNewer>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
I found jpackage's input option takes all files in the specified directory as files to be installed.
To get rid of files not related to execution, I added copy action of jar and change input directory.