### PR TITLE
Refactor OriGeomUtil

### DIFF
--- a/src/main/java/oripa/domain/fold/AssignmentEnumerator.java
+++ b/src/main/java/oripa/domain/fold/AssignmentEnumerator.java
@@ -35,7 +35,6 @@ import oripa.domain.fold.foldability.VertexFoldability;
 import oripa.domain.fold.halfedge.OriEdge;
 import oripa.domain.fold.halfedge.OriVertex;
 import oripa.domain.fold.halfedge.OrigamiModel;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 import oripa.util.StopWatch;
 import oripa.util.collection.CollectionUtil;
@@ -225,9 +224,9 @@ class AssignmentEnumerator {
 		if (!edge.isUnassigned()) {
 			if (vertex.isInsideOfPaper() && vertex.edgeCount() >= 4) {
 				// big-little-big lemma
-				var prevAngle = OriGeomUtil.getAngleDifference(vertex, edgeIndex - 2);
-				var angle = OriGeomUtil.getAngleDifference(vertex, edgeIndex - 1);
-				var nextAngle = OriGeomUtil.getAngleDifference(vertex, edgeIndex);
+				var prevAngle = vertex.getAngleDifference(edgeIndex - 2);
+				var angle = vertex.getAngleDifference(edgeIndex - 1);
+				var nextAngle = vertex.getAngleDifference(edgeIndex);
 				if (prevAngle > angle + MathUtil.angleRadianEps()
 						&& nextAngle > angle + MathUtil.angleRadianEps()) {
 					if (edge.getType() == vertex.getEdge(edgeIndex - 1).getType()) {

--- a/src/main/java/oripa/domain/fold/foldability/BigLittleBigLemma.java
+++ b/src/main/java/oripa/domain/fold/foldability/BigLittleBigLemma.java
@@ -19,7 +19,6 @@
 package oripa.domain.fold.foldability;
 
 import oripa.domain.fold.halfedge.OriVertex;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 import oripa.util.rule.AbstractRule;
 
@@ -56,9 +55,9 @@ public class BigLittleBigLemma extends AbstractRule<OriVertex> {
 				continue;
 			}
 
-			var a1 = OriGeomUtil.getAngleDifference(vertex, i);
-			var a2 = OriGeomUtil.getAngleDifference(vertex, i + 1);
-			var a3 = OriGeomUtil.getAngleDifference(vertex, i + 2);
+			var a1 = vertex.getAngleDifference(i);
+			var a2 = vertex.getAngleDifference(i + 1);
+			var a3 = vertex.getAngleDifference(i + 2);
 
 			if (a1 - a2 > EPS && a3 - a2 > EPS) {
 				lemmaHolds &= e2.getType() != e3.getType();

--- a/src/main/java/oripa/domain/fold/foldability/GeneralizedBigLittleBigLemma.java
+++ b/src/main/java/oripa/domain/fold/foldability/GeneralizedBigLittleBigLemma.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import oripa.domain.fold.halfedge.OriEdge;
 import oripa.domain.fold.halfedge.OriVertex;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 import oripa.util.collection.CollectionUtil;
 import oripa.util.rule.AbstractRule;
@@ -115,7 +114,7 @@ public class GeneralizedBigLittleBigLemma extends AbstractRule<OriVertex> {
 		var edgeNum = vertex.edgeCount();
 
 		final List<Double> angles = IntStream.range(0, edgeNum)
-				.mapToObj(i -> OriGeomUtil.getAngleDifference(vertex, i))
+				.mapToObj(vertex::getAngleDifference)
 				.toList();
 
 		logger.trace("angles = "

--- a/src/main/java/oripa/domain/fold/foldability/KawasakiTheorem.java
+++ b/src/main/java/oripa/domain/fold/foldability/KawasakiTheorem.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oripa.domain.fold.halfedge.OriVertex;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 import oripa.util.rule.AbstractRule;
 
@@ -59,7 +58,7 @@ public class KawasakiTheorem extends AbstractRule<OriVertex> {
 		double oddSum = 0;
 
 		for (int i = 0; i < vertex.edgeCount(); i++) {
-			double angle = OriGeomUtil.getAngleDifference(vertex, i);
+			double angle = vertex.getAngleDifference(i);
 
 			if (i % 2 == 0) {
 				oddSum += angle;

--- a/src/main/java/oripa/domain/fold/foldability/VertexFoldability.java
+++ b/src/main/java/oripa/domain/fold/foldability/VertexFoldability.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import oripa.domain.fold.foldability.ring.RingArrayList;
 import oripa.domain.fold.halfedge.OriVertex;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 import oripa.util.rule.AbstractRule;
 
@@ -124,7 +123,7 @@ public class VertexFoldability extends AbstractRule<OriVertex> {
 		var gaps = new ArrayList<LineGap>();
 
 		for (int i = 0; i < vertex.edgeCount(); i++) {
-			gaps.add(new LineGap(OriGeomUtil.getAngleDifference(vertex, i),
+			gaps.add(new LineGap(vertex.getAngleDifference(i),
 					vertex.getEdge(i).getType()));
 		}
 

--- a/src/main/java/oripa/domain/fold/halfedge/ModelComponentExtractor.java
+++ b/src/main/java/oripa/domain/fold/halfedge/ModelComponentExtractor.java
@@ -21,7 +21,6 @@ package oripa.domain.fold.halfedge;
 import java.util.Collection;
 import java.util.List;
 
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.value.OriLine;
 
 /**
@@ -42,7 +41,7 @@ public class ModelComponentExtractor {
 			final OriFace boundaryFace, final double eps) {
 
 		return wholePrecreases.stream()
-				.filter(p -> OriGeomUtil.isSegmentIncludedInFace(boundaryFace, p, eps))
+				.filter(p -> boundaryFace.isOnFaceInclusively(p, eps))
 				.toList();
 	}
 

--- a/src/main/java/oripa/domain/fold/halfedge/OriFace.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFace.java
@@ -330,8 +330,8 @@ public class OriFace {
 	}
 
 	/**
-	 * Whether {@code face} includes {@code line} entirely. The inclusion test
-	 * is inclusive.
+	 * Whether this face includes {@code line} entirely. The inclusion test is
+	 * inclusive.
 	 *
 	 * @param segment
 	 * @return {@code true} if {@code face} includes {@code line} entirely.

--- a/src/main/java/oripa/domain/fold/halfedge/OriFace.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFace.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import oripa.geom.GeomUtil;
+import oripa.geom.Segment;
 import oripa.util.collection.CollectionUtil;
 import oripa.value.OriLine;
 import oripa.vecmath.Vector2d;
@@ -326,6 +327,18 @@ public class OriFace {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Whether {@code face} includes {@code line} entirely. The inclusion test
+	 * is inclusive.
+	 *
+	 * @param segment
+	 * @return {@code true} if {@code face} includes {@code line} entirely.
+	 */
+	public boolean isOnFaceInclusively(final Segment segment, final double eps) {
+		return isOnFaceInclusively(segment.getP0(), eps)
+				&& isOnFaceInclusively(segment.getP1(), eps);
 	}
 
 	/* (non Javadoc)

--- a/src/main/java/oripa/domain/fold/halfedge/OriVertex.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriVertex.java
@@ -179,6 +179,45 @@ public class OriVertex implements Comparable<OriVertex> {
 		this.vertexID = vertexID;
 	}
 
+	/**
+	 * The angle between edges v1-v2 and v2-v3.
+	 *
+	 * @param v1
+	 * @param v2
+	 * @param v3
+	 * @return 0 to 2 * pi between edges v1-v2 and v2-v3
+	 */
+	private double getAngleDifference(
+			final OriVertex v1, final OriVertex v2, final OriVertex v3) {
+		var p = v2.getPositionBeforeFolding();
+		var preP = v1.getPositionBeforeFolding().subtract(p);
+		var nxtP = v3.getPositionBeforeFolding().subtract(p);
+
+		var prePAngle = preP.ownAngle();
+		var nxtPAngle = nxtP.ownAngle();
+
+		if (prePAngle > nxtPAngle) {
+			nxtPAngle += 2 * Math.PI;
+		}
+
+		return nxtPAngle - prePAngle;
+
+//		return preP.angle(nxtP); // fails if a concave face exists.
+	}
+
+	/**
+	 * The angle between i-th edge and (i+1)-th edge incident to this vertex.
+	 *
+	 * @param index
+	 * @return 0 to 2 * pi between i-th edge and (i+1)-th edge
+	 */
+	public double getAngleDifference(final int index) {
+		return getAngleDifference(
+				getOppositeVertex(index),
+				this,
+				getOppositeVertex(index + 1));
+	}
+
 	@Override
 	public int compareTo(final OriVertex o) {
 		return new OriPoint(positionBeforeFolding).compareTo(new OriPoint(o.positionBeforeFolding));

--- a/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oripa.domain.cptool.ElementRemover;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.geom.RectangleDomain;
 import oripa.util.StopWatch;
 import oripa.value.OriLine;
@@ -207,7 +206,7 @@ public class OrigamiModelFactory {
 		// attach precrease lines to faces
 		for (OriFace face : faces) {
 			face.setPrecreases(modelPrecreases.stream()
-					.filter(precrease -> OriGeomUtil.isSegmentIncludedInFace(face, precrease, pointEps))
+					.filter(precrease -> face.isOnFaceInclusively(precrease, pointEps))
 					.toList());
 		}
 		origamiModel.setHasModel(true);

--- a/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
+++ b/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
@@ -18,6 +18,8 @@
  */
 package oripa.domain.fold.origeom;
 
+import java.util.function.Predicate;
+
 import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.halfedge.OriHalfedge;
 import oripa.geom.GeomUtil;
@@ -119,8 +121,10 @@ public class OriGeomUtil {
 		Vector2d p2 = heg.getNext().getPosition();
 		var heLine = new Segment(p1, p2).getLine();
 
-		return face.halfedgeStream().anyMatch(he -> GeomUtil.distancePointToLine(he.getPosition(), heLine) < eps
-				&& GeomUtil.distancePointToLine(he.getNext().getPosition(), heLine) < eps);
+		Predicate<Vector2d> isOnLine = p -> GeomUtil.distancePointToLine(p, heLine) < eps;
+
+		return face.halfedgeStream().anyMatch(he -> isOnLine.test(he.getPosition())
+				&& isOnLine.test(he.getNext().getPosition()));
 	}
 
 	private static boolean isHalfedgeCrossTwoEdgesOfFace(final OriFace face, final OriHalfedge heg, final double eps) {
@@ -148,7 +152,7 @@ public class OriGeomUtil {
 	}
 
 	private static boolean isHalfedgeCrossEdgeOrIncluded(final OriFace face, final OriHalfedge heg, final double eps) {
-		// If at least one of the endpoints is fully contained
+		// If at least one of the end points is fully contained
 
 		return face.isOnFaceExclusively(heg.getPosition(), eps)
 				|| face.isOnFaceExclusively(heg.getNext().getPosition(), eps);

--- a/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
+++ b/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
@@ -154,19 +154,6 @@ public class OriGeomUtil {
 	}
 
 	/**
-	 * Whether {@code face} includes {@code line} entirely. The inclusion test
-	 * is inclusive.
-	 *
-	 * @param face
-	 * @param line
-	 * @return {@code true} if {@code face} includes {@code line} entirely.
-	 */
-	public static boolean isSegmentIncludedInFace(final OriFace face, final Segment line, final double eps) {
-		return face.isOnFaceInclusively(line.getP0(), eps)
-				&& face.isOnFaceInclusively(line.getP1(), eps);
-	}
-
-	/**
 	 * The angle between edges v1-v2 and v2-v3.
 	 *
 	 * @param v1

--- a/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
+++ b/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
@@ -20,13 +20,14 @@ package oripa.domain.fold.origeom;
 
 import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.halfedge.OriHalfedge;
-import oripa.domain.fold.halfedge.OriVertex;
 import oripa.geom.GeomUtil;
 import oripa.geom.Segment;
 import oripa.vecmath.Vector2d;
 
 /**
- * Mathematical operations related to half-edge data structure elements.
+ * Mathematical operations related to half-edge data structure elements. This
+ * class contains complex methods or methods that responsibility among related
+ * objects is ambiguous.
  *
  * @author OUCHI Koji
  *
@@ -153,43 +154,4 @@ public class OriGeomUtil {
 				|| face.isOnFaceExclusively(heg.getNext().getPosition(), eps);
 	}
 
-	/**
-	 * The angle between edges v1-v2 and v2-v3.
-	 *
-	 * @param v1
-	 * @param v2
-	 * @param v3
-	 * @return 0 to 2 * pi between edges v1-v2 and v2-v3
-	 */
-	private static double getAngleDifference(
-			final OriVertex v1, final OriVertex v2, final OriVertex v3) {
-		var p = v2.getPositionBeforeFolding();
-		var preP = v1.getPositionBeforeFolding().subtract(p);
-		var nxtP = v3.getPositionBeforeFolding().subtract(p);
-
-		var prePAngle = preP.ownAngle();
-		var nxtPAngle = nxtP.ownAngle();
-
-		if (prePAngle > nxtPAngle) {
-			nxtPAngle += 2 * Math.PI;
-		}
-
-		return nxtPAngle - prePAngle;
-
-//		return preP.angle(nxtP); // fails if a concave face exists.
-	}
-
-	/**
-	 * The angle between i-th edge and (i+1)-th edge incident to {@code v}.
-	 *
-	 * @param v
-	 * @param index
-	 * @return 0 to 2 * pi between i-th edge and (i+1)-th edge
-	 */
-	public static double getAngleDifference(final OriVertex v, final int index) {
-		return getAngleDifference(
-				v.getOppositeVertex(index),
-				v,
-				v.getOppositeVertex(index + 1));
-	}
 }

--- a/src/main/java/oripa/domain/suggestion/KawasakiTheoremSuggester.java
+++ b/src/main/java/oripa/domain/suggestion/KawasakiTheoremSuggester.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.List;
 
 import oripa.domain.fold.halfedge.OriVertex;
-import oripa.domain.fold.origeom.OriGeomUtil;
 import oripa.util.MathUtil;
 
 /**
@@ -55,17 +54,17 @@ public class KawasakiTheoremSuggester {
 		double evenSum = 0;
 
 		for (int i = 0; i < angleCount; i += 2) {
-			evenSum += OriGeomUtil.getAngleDifference(vertex, i);
+			evenSum += vertex.getAngleDifference(i);
 		}
 
 		double oddSum = 2 * Math.PI - evenSum;
 
-		evenSum -= OriGeomUtil.getAngleDifference(vertex, 0);
+		evenSum -= vertex.getAngleDifference(0);
 
 		// computes as if indices are re-assigned as current i-th is the new
 		// 0th.
 		for (var i = 0; i < angleCount; i++) {
-			double theta = OriGeomUtil.getAngleDifference(vertex, i);
+			double theta = vertex.getAngleDifference(i);
 			double t = evenSum + theta - Math.PI;
 
 			final double EPS = MathUtil.angleRadianEps();
@@ -75,7 +74,7 @@ public class KawasakiTheoremSuggester {
 			}
 
 			var tmpEvenSum = evenSum;
-			evenSum = oddSum + theta - OriGeomUtil.getAngleDifference(vertex, i + 1);
+			evenSum = oddSum + theta - vertex.getAngleDifference(i + 1);
 			oddSum = tmpEvenSum;
 		}
 

--- a/src/main/java/oripa/geom/GeomUtil.java
+++ b/src/main/java/oripa/geom/GeomUtil.java
@@ -632,9 +632,4 @@ public class GeomUtil {
 				.get();
 		return sum.multiply(1.0 / points.size());
 	}
-
-	public static boolean isInterior(final Segment s, final Vector2d p, final double pointEps) {
-		return s.pointStream().noneMatch(q -> p.equals(q, pointEps)) && distancePointToSegment(p, s) < pointEps;
-	}
-
 }

--- a/src/test/java/oripa/domain/fold/halfedge/OriFaceTest.java
+++ b/src/test/java/oripa/domain/fold/halfedge/OriFaceTest.java
@@ -67,7 +67,7 @@ class OriFaceTest {
 	 * {@link oripa.domain.fold.halfedge.OriFace#isOnFaceInclusively(oripa.vecmath.Vector2d)}.
 	 */
 	@Test
-	void testIsOnFaceInclusively() {
+	void testIsOnFaceInclusively_vertex() {
 		assertTrue(face.isOnFaceInclusively(new Vector2d(5, 5), 1e-6));
 		assertTrue(face.isOnFaceInclusively(new Vector2d(5, 10 + 1e-8), 1e-6));
 		assertFalse(face.isOnFaceInclusively(new Vector2d(5, 10.1), 1e-6));

--- a/src/test/java/oripa/domain/fold/halfedge/OriVertexTest.java
+++ b/src/test/java/oripa/domain/fold/halfedge/OriVertexTest.java
@@ -34,11 +34,8 @@ import oripa.value.OriLine;
  */
 @ExtendWith(MockitoExtension.class)
 class OriVertexTest {
+	final static double EPS = 1e-8;
 
-	/**
-	 * Test method for
-	 * {@link oripa.domain.fold.halfedge.OriVertex#addEdge(oripa.domain.fold.halfedge.OriEdge)}.
-	 */
 	@Test
 	void testAddEdge() {
 		var vertex = new OriVertex(1, 1);
@@ -52,7 +49,7 @@ class OriVertexTest {
 		var v3 = new OriVertex(0, 1 - 1e-8); // -180 deg.
 		var e3 = new OriEdge(vertex, v3, OriLine.Type.MOUNTAIN.toInt());
 
-		Stream.of(e1, e2, e3).forEach(e -> vertex.addEdge(e));
+		Stream.of(e1, e2, e3).forEach(vertex::addEdge);
 
 		assertSame(e1, vertex.getEdge(0));
 		assertSame(e2, vertex.getEdge(1));
@@ -68,6 +65,46 @@ class OriVertexTest {
 		assertSame(e2, vertex.getEdge(1));
 		assertSame(e3, vertex.getEdge(2));
 		assertSame(e4, vertex.getEdge(3));
+	}
+
+	@Test
+	void testGetAngleDifference_lessThanOrEqualToPi() {
+		var vertex = new OriVertex(1, 1);
+
+		var v1 = new OriVertex(2, 1); // 0 deg.
+		var e1 = new OriEdge(vertex, v1, OriLine.Type.MOUNTAIN.toInt());
+
+		var v2 = new OriVertex(2, 2); // 45 deg.
+		var e2 = new OriEdge(vertex, v2, OriLine.Type.MOUNTAIN.toInt());
+
+		var v3 = new OriVertex(0, 1 - EPS * 0.1); // -180 deg.
+		var e3 = new OriEdge(vertex, v3, OriLine.Type.MOUNTAIN.toInt());
+
+		Stream.of(e1, e2, e3).forEach(vertex::addEdge);
+
+		assertEquals(Math.PI / 4, vertex.getAngleDifference(0), EPS);
+		assertEquals(3 * Math.PI / 4, vertex.getAngleDifference(1), EPS);
+		assertEquals(Math.PI, vertex.getAngleDifference(2), EPS);
+	}
+
+	@Test
+	void testGetAngleDifference_largerThanPi() {
+		var vertex = new OriVertex(1, 1);
+
+		var v1 = new OriVertex(2, 1); // 0 deg.
+		var e1 = new OriEdge(vertex, v1, OriLine.Type.MOUNTAIN.toInt());
+
+		var v2 = new OriVertex(2, 2); // 45 deg.
+		var e2 = new OriEdge(vertex, v2, OriLine.Type.MOUNTAIN.toInt());
+
+		var v3 = new OriVertex(0, 2); // 135 deg.
+		var e3 = new OriEdge(vertex, v3, OriLine.Type.MOUNTAIN.toInt());
+
+		Stream.of(e1, e2, e3).forEach(vertex::addEdge);
+
+		assertEquals(Math.PI / 4, vertex.getAngleDifference(0), EPS);
+		assertEquals(Math.PI / 2, vertex.getAngleDifference(1), EPS);
+		assertEquals(5 * Math.PI / 4, vertex.getAngleDifference(2), EPS);
 	}
 
 }


### PR DESCRIPTION
Move methods to halfedge objects:
* `isSegmentIncludedInFace()` is moved to `OriFace` and renamed `isOnFaceInclusively()`.
* `getAngleDifference()` is moved to `OriVertex`.