### PR TITLE
Improve layer ordering

### DIFF
--- a/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
+++ b/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
@@ -141,9 +141,12 @@ class LayerOrderEnumerator {
 		// subface ordering.
 		subfaces = subfaces.stream()
 				.sorted(Comparator
-						.comparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf2Faces(overlapRelation))
-						.thenComparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf3Faces(overlapRelation))
-						.thenComparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf4Faces(overlapRelation))
+						.comparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf2Faces(overlapRelation)
+								/ sub.getParentFaceCount())
+						.thenComparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf3Faces(overlapRelation)
+								/ sub.getParentFaceCount())
+						.thenComparingInt((final SubFace sub) -> sub.getAllCountOfConditionsOf4Faces(overlapRelation)
+								/ sub.getParentFaceCount())
 						.reversed())
 				.toList();
 		logger.debug("subface ordering = {}[ms]", watch.getMilliSec());

--- a/src/main/java/oripa/util/BitBlockByteMatrix.java
+++ b/src/main/java/oripa/util/BitBlockByteMatrix.java
@@ -30,6 +30,18 @@ public class BitBlockByteMatrix implements ByteMatrix {
 	private final int rowCount, columnCount;
 	private final int blockLength;
 
+	private static final boolean[] BLOCK_LENGTH_AVAILABLE = new boolean[] {
+			false, // 0
+			true, // 1
+			true, // 2
+			false, // 3
+			true, // 4
+			false, // 5
+			false, // 6
+			false, // 7
+			true, // 8
+	};
+
 	private final long mask;
 
 	public BitBlockByteMatrix(final int rowCount, final int columnCount, final int blockLength) {
@@ -38,6 +50,10 @@ public class BitBlockByteMatrix implements ByteMatrix {
 		if (blockLength > 8) {
 			throw new IllegalArgumentException("block length should be less than or equal to 8.");
 		}
+		if (!BLOCK_LENGTH_AVAILABLE[blockLength]) {
+			throw new IllegalArgumentException("block length should be 1,2,4 or 8.");
+		}
+
 		this.blockLength = blockLength;
 
 		int necessaryBits = columnCount * blockLength;

--- a/src/main/java/oripa/util/Matrices.java
+++ b/src/main/java/oripa/util/Matrices.java
@@ -20,12 +20,21 @@ package oripa.util;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * @author OUCHI Koji
  *
  */
 public class Matrices {
+
+	public static <T> void fill(final T[][] matrix, final Supplier<T> initialValueFactory) {
+		for (int row = 0; row < matrix.length; row++) {
+			for (int column = 0; column < matrix[row].length; column++) {
+				matrix[row][column] = initialValueFactory.get();
+			}
+		}
+	}
 
 	/**
 	 * copies {@code from} matrix to {@code to} matrix.


### PR DESCRIPTION
Usually, the fewer faces on a subface are, the easier ordering gets. This PR reflects the assumption by modifying the heuristic score  to have a division by the number of the faces on a subface.