### PR TITLE
Computation type selection

### DIFF
--- a/src/main/java/oripa/cli/CommandLineFolder.java
+++ b/src/main/java/oripa/cli/CommandLineFolder.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oripa.application.main.DataFileAccess;
+import oripa.domain.fold.Folder;
 import oripa.domain.fold.FolderFactory;
 import oripa.domain.fold.TestedOrigamiModelFactory;
 import oripa.domain.fold.halfedge.OrigamiModel;
@@ -66,7 +67,7 @@ public class CommandLineFolder {
 			}
 
 			var folder = new FolderFactory().create(origamiModel.getModelType());
-			var foldedModel = folder.fold(origamiModel, pointEps, true);
+			var foldedModel = folder.fold(origamiModel, pointEps, Folder.EstimationType.FULL);
 
 			if (split) {
 				var digitLength = Integer.toString(foldedModel.getFoldablePatternCount()).length();

--- a/src/main/java/oripa/domain/fold/AssignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/AssignedModelFolder.java
@@ -37,16 +37,16 @@ class AssignedModelFolder implements Folder {
 	}
 
 	@Override
-	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final boolean fullEstimation) {
+	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
 		simpleFolder.simpleFoldWithoutZorder(origamiModel);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 
-		if (!fullEstimation) {
+		if (estimationType == EstimationType.X_RAY) {
 			origamiModel.setFolded(true);
 			return new FoldedModel(origamiModel, List.of(), List.of());
 		}
 
-		var enumerationResult = enumerator.enumerate(origamiModel, eps);
+		var enumerationResult = enumerator.enumerate(origamiModel, eps, estimationType == EstimationType.FITST_ONLY);
 
 		var foldedModel = new FoldedModel(origamiModel, enumerationResult.getOverlapRelations(),
 				enumerationResult.getSubfaces());

--- a/src/main/java/oripa/domain/fold/AssignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/AssignedModelFolder.java
@@ -46,7 +46,7 @@ class AssignedModelFolder implements Folder {
 			return new FoldedModel(origamiModel, List.of(), List.of());
 		}
 
-		var enumerationResult = enumerator.enumerate(origamiModel, eps, estimationType == EstimationType.FITST_ONLY);
+		var enumerationResult = enumerator.enumerate(origamiModel, eps, estimationType == EstimationType.FIRST_ONLY);
 
 		var foldedModel = new FoldedModel(origamiModel, enumerationResult.getOverlapRelations(),
 				enumerationResult.getSubfaces());

--- a/src/main/java/oripa/domain/fold/DeterministicLayerOrderEstimator.java
+++ b/src/main/java/oripa/domain/fold/DeterministicLayerOrderEstimator.java
@@ -148,7 +148,7 @@ class DeterministicLayerOrderEstimator {
 		});
 
 		// penetration
-		correct &= faces.stream().allMatch(f_i -> {
+		correct &= faces.parallelStream().allMatch(f_i -> {
 			int i = f_i.getFaceID();
 
 			for (var he : f_i.halfedgeIterable()) {

--- a/src/main/java/oripa/domain/fold/ErrorAllowedFolder.java
+++ b/src/main/java/oripa/domain/fold/ErrorAllowedFolder.java
@@ -38,7 +38,7 @@ class ErrorAllowedFolder implements Folder {
 	}
 
 	@Override
-	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final boolean fullEstimation) {
+	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
 		simpleFolder.foldWithoutLineType(origamiModel);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 

--- a/src/main/java/oripa/domain/fold/Folder.java
+++ b/src/main/java/oripa/domain/fold/Folder.java
@@ -27,7 +27,7 @@ import oripa.domain.fold.halfedge.OrigamiModel;
 public interface Folder {
 	enum EstimationType {
 		FULL,
-		FITST_ONLY,
+		FIRST_ONLY,
 		X_RAY
 	}
 

--- a/src/main/java/oripa/domain/fold/Folder.java
+++ b/src/main/java/oripa/domain/fold/Folder.java
@@ -25,6 +25,11 @@ import oripa.domain.fold.halfedge.OrigamiModel;
  *
  */
 public interface Folder {
+	enum EstimationType {
+		FULL,
+		FITST_ONLY,
+		X_RAY
+	}
 
 	/**
 	 * Computes folded states.
@@ -40,5 +45,5 @@ public interface Folder {
 	 * @return folded model whose {@link FoldedModel#getOrigamiModel()} returns
 	 *         the given {@code origamiModel}.
 	 */
-	FoldedModel fold(OrigamiModel origamiModel, double eps, boolean fullEstimation);
+	FoldedModel fold(OrigamiModel origamiModel, double eps, EstimationType estimationType);
 }

--- a/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
+++ b/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
@@ -78,6 +78,8 @@ class LayerOrderEnumerator {
 
 	private final boolean shouldLogStats;
 
+	private boolean firstOnly;
+
 	public LayerOrderEnumerator(final SubFacesFactory subfacesFactory, final boolean shouldLogStats) {
 		this.subfacesFactory = subfacesFactory;
 		this.shouldLogStats = shouldLogStats;
@@ -88,10 +90,14 @@ class LayerOrderEnumerator {
 	 *            half-edge based data for origami model after moving faces.
 	 * @param eps
 	 *            max value of computation error.
+	 * @param firstOnly
+	 *            true for only one state.
 	 */
-	public Result enumerate(final OrigamiModel origamiModel, final double eps) {
+	public Result enumerate(final OrigamiModel origamiModel, final double eps, final boolean firstOnly) {
 		var faces = origamiModel.getFaces();
 		var edges = origamiModel.getEdges();
+
+		this.firstOnly = firstOnly;
 
 		// construct the subfaces
 		final double paperSize = origamiModel.getPaperSize();
@@ -207,6 +213,10 @@ class LayerOrderEnumerator {
 			final OverlapRelation overlapRelation,
 			final Collection<OverlapRelation> overlapRelations) {
 		callCount.incrementAndGet();
+
+		if (firstOnly && !overlapRelations.isEmpty()) {
+			return 0;
+		}
 
 		if (subfaces.isEmpty()) {
 			var answer = overlapRelation.clone();

--- a/src/main/java/oripa/domain/fold/OverlapRelationFactory.java
+++ b/src/main/java/oripa/domain/fold/OverlapRelationFactory.java
@@ -108,7 +108,7 @@ class OverlapRelationFactory {
 		logger.debug("sparsity of overlap relation matrix = {}", rate);
 		// One element in dictionary of keys for byte value needs at least 16
 		// bytes.
-		if (rate > 15.0 / 16) {
+		if (rate > 0.99) {
 			logger.debug("use sparse matrix for overlap relation.");
 			overlapRelation.switchToSparseMatrix();
 		}

--- a/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
@@ -51,7 +51,7 @@ class UnassignedModelFolder implements Folder {
 		var foldedModels = new ArrayList<FoldedModel>();
 
 		var assignmentEnumerator = new AssignmentEnumerator(model -> {
-			var result = layerOrderEnumerator.enumerate(model, eps, estimationType == EstimationType.FITST_ONLY);
+			var result = layerOrderEnumerator.enumerate(model, eps, estimationType == EstimationType.FIRST_ONLY);
 			foldedModels.add(new FoldedModel(model, result.getOverlapRelations(), result.getSubfaces()));
 		});
 

--- a/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
@@ -39,11 +39,11 @@ class UnassignedModelFolder implements Folder {
 	}
 
 	@Override
-	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final boolean fullEstimation) {
+	public FoldedModel fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
 		simpleFolder.simpleFoldWithoutZorder(origamiModel);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 
-		if (!fullEstimation) {
+		if (estimationType == EstimationType.X_RAY) {
 			origamiModel.setFolded(true);
 			return new FoldedModel(origamiModel, List.of(), List.of());
 		}
@@ -51,7 +51,7 @@ class UnassignedModelFolder implements Folder {
 		var foldedModels = new ArrayList<FoldedModel>();
 
 		var assignmentEnumerator = new AssignmentEnumerator(model -> {
-			var result = layerOrderEnumerator.enumerate(model, eps);
+			var result = layerOrderEnumerator.enumerate(model, eps, estimationType == EstimationType.FITST_ONLY);
 			foldedModels.add(new FoldedModel(model, result.getOverlapRelations(), result.getSubfaces()));
 		});
 

--- a/src/main/java/oripa/gui/presenter/main/ModelComputationFacade.java
+++ b/src/main/java/oripa/gui/presenter/main/ModelComputationFacade.java
@@ -18,8 +18,10 @@
  */
 package oripa.gui.presenter.main;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -27,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import oripa.domain.creasepattern.CreasePattern;
 import oripa.domain.fold.FoldedModel;
+import oripa.domain.fold.Folder.EstimationType;
 import oripa.domain.fold.FolderFactory;
 import oripa.domain.fold.TestedOrigamiModelFactory;
 import oripa.domain.fold.halfedge.OrigamiModel;
@@ -37,6 +40,39 @@ import oripa.domain.fold.halfedge.OrigamiModel;
  */
 public class ModelComputationFacade {
 	private static final Logger logger = LoggerFactory.getLogger(ModelComputationFacade.class);
+
+	public enum ComputationType {
+		FULL(EstimationType.FULL, "All folded states", true),
+		FIRST_ONLY(EstimationType.FITST_ONLY, "First folded state", true),
+		X_RAY(EstimationType.X_RAY, "X-Ray", false);
+
+		private final EstimationType estimationType;
+		private final String name;
+		private final boolean isLayerOrdering;
+
+		private ComputationType(final EstimationType estimationType, final String name, final boolean isLayerOrdering) {
+			this.estimationType = estimationType;
+			this.name = name;
+			this.isLayerOrdering = isLayerOrdering;
+		}
+
+		public boolean isLayerOrdering() {
+			return isLayerOrdering;
+		}
+
+		EstimationType toEstimationType() {
+			return estimationType;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		public static Optional<ComputationType> fromString(final String s) {
+			return Arrays.stream(values()).filter(v -> v.toString().equals(s)).findFirst();
+		}
+	}
 
 	public class ComputationResult {
 		private final List<OrigamiModel> origamiModels;
@@ -96,12 +132,12 @@ public class ModelComputationFacade {
 
 	public ComputationResult computeModels(
 			final List<OrigamiModel> origamiModels,
-			final boolean fullEstimation) {
+			final ComputationType type) {
 
 		var folderFactory = new FolderFactory();
 
 		var foldedModels = origamiModels.stream()
-				.map(model -> folderFactory.create(model.getModelType()).fold(model, eps, fullEstimation))
+				.map(model -> folderFactory.create(model.getModelType()).fold(model, eps, type.toEstimationType()))
 				.toList();
 
 		return new ComputationResult(origamiModels, foldedModels);

--- a/src/main/java/oripa/gui/presenter/main/ModelComputationFacade.java
+++ b/src/main/java/oripa/gui/presenter/main/ModelComputationFacade.java
@@ -43,7 +43,7 @@ public class ModelComputationFacade {
 
 	public enum ComputationType {
 		FULL(EstimationType.FULL, "All folded states", true),
-		FIRST_ONLY(EstimationType.FITST_ONLY, "First folded state", true),
+		FIRST_ONLY(EstimationType.FIRST_ONLY, "First folded state", true),
 		X_RAY(EstimationType.X_RAY, "X-Ray", false);
 
 		private final EstimationType estimationType;

--- a/src/main/java/oripa/gui/presenter/main/UIPanelPresenter.java
+++ b/src/main/java/oripa/gui/presenter/main/UIPanelPresenter.java
@@ -41,6 +41,7 @@ import oripa.gui.presenter.creasepattern.byvalue.AngleMeasuringAction;
 import oripa.gui.presenter.creasepattern.byvalue.LengthMeasuringAction;
 import oripa.gui.presenter.estimation.EstimationResultFramePresenter;
 import oripa.gui.presenter.main.ModelComputationFacade.ComputationResult;
+import oripa.gui.presenter.main.ModelComputationFacade.ComputationType;
 import oripa.gui.presenter.model.ModelViewFramePresenter;
 import oripa.gui.presenter.plugin.GraphicMouseActionPlugin;
 import oripa.gui.view.FrameView;
@@ -74,6 +75,9 @@ public class UIPanelPresenter {
 	private final TypeForChange[] alterLineComboDataTo = {
 			TypeForChange.FLIP, TypeForChange.MOUNTAIN, TypeForChange.VALLEY, TypeForChange.UNASSIGNED,
 			TypeForChange.AUX, TypeForChange.CUT, TypeForChange.DELETE, };
+
+	private final ComputationType[] computationTypeComboData = {
+			ComputationType.FULL, ComputationType.FIRST_ONLY, ComputationType.X_RAY };
 
 	private final ByValueContext byValueContext;
 
@@ -125,7 +129,7 @@ public class UIPanelPresenter {
 
 		Stream.of(alterLineComboDataFrom).forEach(item -> view.addItemOfAlterLineComboFrom(item.toString()));
 		Stream.of(alterLineComboDataTo).forEach(item -> view.addItemOfAlterLineComboTo(item.toString()));
-
+		Stream.of(computationTypeComboData).forEach(item -> view.addItemOfComputationTypeCombo(item.toString()));
 		Stream.of(AngleStep.values()).forEach(item -> view.addItemOfAngleStepCombo(item.toString()));
 
 		addListeners();
@@ -135,7 +139,8 @@ public class UIPanelPresenter {
 
 		view.initializeButtonSelection(AngleStep.PI_OVER_8.toString(),
 				typeForChangeContext.getTypeFrom().toString(),
-				typeForChangeContext.getTypeTo().toString());
+				typeForChangeContext.getTypeTo().toString(),
+				ComputationType.FULL.toString());
 
 		updateValuePanelFractionDigits();
 	}
@@ -354,7 +359,11 @@ public class UIPanelPresenter {
 
 		computationResult = modelComputation.computeModels(
 				origamiModels,
-				view.isFullEstimation());
+				getComputationType());
+	}
+
+	private ComputationType getComputationType() {
+		return ComputationType.fromString(view.getComputationType()).get();
 	}
 
 	private void showFoldedModelWindows() {
@@ -388,7 +397,7 @@ public class UIPanelPresenter {
 
 		EstimationResultFrameView resultFrame = null;
 
-		if (view.isFullEstimation()) {
+		if (getComputationType().isLayerOrdering()) {
 			var count = computationResult.countFoldablePatterns();
 			if (count == 0) {
 				// no answer is found.

--- a/src/main/java/oripa/gui/view/main/UIPanelView.java
+++ b/src/main/java/oripa/gui/view/main/UIPanelView.java
@@ -33,7 +33,7 @@ public interface UIPanelView extends View {
 
 	// UIPanelSetting getUIPanelSetting();
 
-	void initializeButtonSelection(String angleStep, String typeFrom, String typeTo);
+	void initializeButtonSelection(String angleStep, String typeFrom, String typeTo, String computationType);
 
 	void addItemOfAlterLineComboFrom(String item);
 
@@ -47,6 +47,8 @@ public interface UIPanelView extends View {
 
 	void addGridChangeButtonListener(Consumer<Integer> listener);
 
+	void addItemOfComputationTypeCombo(String item);
+
 	void setGridDivNum(int gridDivNum);
 
 	void setEstimationResultColors(Color front, Color back);
@@ -57,7 +59,7 @@ public interface UIPanelView extends View {
 
 	void setByValueLength(double length);
 
-	boolean isFullEstimation();
+	String getComputationType();
 
 	Color getEstimationResultFrontColor();
 

--- a/src/main/java/oripa/swing/view/main/UIPanel.java
+++ b/src/main/java/oripa/swing/view/main/UIPanel.java
@@ -190,10 +190,7 @@ public class UIPanel extends JPanel implements UIPanelView {
 	private final JCheckBox dispVertexCheckBox = new JCheckBox(
 			resources.getString(ResourceKey.LABEL, StringID.UI.SHOW_VERTICES_ID),
 			InitialVisibilities.VERTEX);
-	private final JCheckBox doFullEstimationCheckBox = new JCheckBox(
-			resources.getString(ResourceKey.LABEL,
-					StringID.UI.FULL_ESTIMATION_ID),
-			false);
+	private final JComboBox<String> computationTypeCombo = new JComboBox<String>();
 	private final JCheckBox zeroLineWidthCheckBox = new JCheckBox(
 			resources.getString(ResourceKey.LABEL, StringID.UI.ZERO_LINE_WIDTH_ID),
 			InitialVisibilities.ZERO_LINE_WIDTH);
@@ -300,7 +297,8 @@ public class UIPanel extends JPanel implements UIPanelView {
 	}
 
 	@Override
-	public void initializeButtonSelection(final String angleStep, final String typeFrom, final String typeTo) {
+	public void initializeButtonSelection(final String angleStep, final String typeFrom, final String typeTo,
+			final String computationType) {
 		// -------------------------------------------------
 		// Initialize selection
 		// -------------------------------------------------
@@ -315,7 +313,7 @@ public class UIPanel extends JPanel implements UIPanelView {
 		alterLineComboFrom.setSelectedItem(typeFrom);
 		alterLineComboTo.setSelectedItem(typeTo);
 
-		doFullEstimationCheckBox.setSelected(true);
+		computationTypeCombo.setSelectedItem(computationType);
 		lineTypeMountainButton.doClick();
 
 	}
@@ -605,7 +603,7 @@ public class UIPanel extends JPanel implements UIPanelView {
 
 		var gbBuilder = new GridBagConstraintsBuilder(3);
 
-		buttonsPanel.add(doFullEstimationCheckBox, gbBuilder.getLineField());
+		buttonsPanel.add(computationTypeCombo, gbBuilder.getLineField());
 
 		buttonsPanel.add(checkWindowButton, gbBuilder.getLineField());
 		buttonsPanel.add(buildButton, gbBuilder.getLineField());
@@ -823,6 +821,16 @@ public class UIPanel extends JPanel implements UIPanelView {
 	@Override
 	public void addItemOfAngleStepCombo(final String item) {
 		angleStepCombo.addItem(item);
+	}
+
+	@Override
+	public void addItemOfComputationTypeCombo(final String item) {
+		computationTypeCombo.addItem(item);
+	}
+
+	@Override
+	public String getComputationType() {
+		return (String) computationTypeCombo.getSelectedItem();
 	}
 
 	@Override
@@ -1228,11 +1236,6 @@ public class UIPanel extends JPanel implements UIPanelView {
 	@Override
 	public BiConsumer<Color, Color> getEstimationResultSaveColorsListener() {
 		return estimationResultSaveColorsListener;
-	}
-
-	@Override
-	public boolean isFullEstimation() {
-		return doFullEstimationCheckBox.isSelected();
 	}
 
 	@Override


### PR DESCRIPTION
Sometimes computing all folded states does too much to check global foldability, and fails if the input is very complex.
"First folded state only" mode is added for that purpose.