### PR TITLE
Use gradle wrapper validation in Github actions.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,11 +9,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
+
+    - name: Gradle wrapper validation
+      uses: gradle/actions/wrapper-validation@v3
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
     - name: Build with Gradle

--- a/.github/workflows/release_gradle.yml
+++ b/.github/workflows/release_gradle.yml
@@ -47,6 +47,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Gradle wrapper validation
+        uses: gradle/actions/wrapper-validation@v3
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 


### PR DESCRIPTION
Keeps this repository away from injection of malicious gradle wrapper.