### PR TITLE
Fix behavior of line-to-line axiom when segments are on the same line.

### DIFF
--- a/src/main/java/oripa/domain/cptool/LineToLineAxiom.java
+++ b/src/main/java/oripa/domain/cptool/LineToLineAxiom.java
@@ -43,16 +43,33 @@ public class LineToLineAxiom {
 		var line0 = s0.getLine();
 		var line1 = s1.getLine();
 
+		if (line0.equals(line1, pointEps)) {
+			if (GeomUtil.isOverlap(s0, s1, pointEps)) {
+				// out of consideration.
+				return List.of();
+			}
+			return createForSegmentsOnTheSameLine(s0, s1);
+		}
+
 		if (line0.isParallel(line1)) {
 			return createForParallelSegments(line0, line1);
-		} else {
-
-			var segmentCrossPointOpt = GeomUtil.getCrossPoint(s0, s1);
-
-			return segmentCrossPointOpt
-					.map(crossPoint -> createForSegmentsWithCross(s0, s1, crossPoint, pointEps))
-					.orElse(createForSegmentsWithoutCross(s0, s1, pointEps));
 		}
+
+		var segmentCrossPointOpt = GeomUtil.getCrossPoint(s0, s1);
+
+		return segmentCrossPointOpt
+				.map(crossPoint -> createForSegmentsWithCross(s0, s1, crossPoint, pointEps))
+				.orElse(createForSegmentsWithoutCross(s0, s1, pointEps));
+
+	}
+
+	private List<Line> createForSegmentsOnTheSameLine(final Segment s0, final Segment s1) {
+		var p0 = GeomUtil.getNearestPointToSegment(s1.getP0(), s0);
+		var p1 = GeomUtil.getNearestPointToSegment(s0.getP0(), s1);
+
+		var p = p0.add(p1).multiply(0.5);
+
+		return List.of(new Line(p, s0.getLine().getDirection().getRightSidePerpendicular()));
 	}
 
 	private List<Line> createForParallelSegments(final Line line0, final Line line1) {

--- a/src/main/java/oripa/domain/cptool/LineToLineAxiom.java
+++ b/src/main/java/oripa/domain/cptool/LineToLineAxiom.java
@@ -63,6 +63,14 @@ public class LineToLineAxiom {
 
 	}
 
+	/**
+	 * Extended interpretation of the axiom. This method returns the
+	 * perpendicular bisector of the closest points between the given segments.
+	 *
+	 * @param s0
+	 * @param s1
+	 * @return
+	 */
 	private List<Line> createForSegmentsOnTheSameLine(final Segment s0, final Segment s1) {
 		var p0 = GeomUtil.getNearestPointToSegment(s1.getP0(), s0);
 		var p1 = GeomUtil.getNearestPointToSegment(s0.getP0(), s1);

--- a/src/test/java/oripa/domain/cptool/LineToLineAxiomTest.java
+++ b/src/test/java/oripa/domain/cptool/LineToLineAxiomTest.java
@@ -14,6 +14,26 @@ class LineToLineAxiomTest {
 	double EPS = 1e-5;
 
 	@Test
+	void testCreateFoldLinesOnTheSameLine() {
+		var s0 = new Segment(new Vector2d(-100, 0), new Vector2d(-50, 0));
+		var s1 = new Segment(new Vector2d(50, 0), new Vector2d(100, 0));
+
+		var lines = new LineToLineAxiom().createFoldLines(s0, s1, EPS);
+
+		assertEquals(1, lines.size());
+
+		var line = lines.get(0);
+
+		var dir = line.getDirection();
+
+		assertEquals(0, dir.getX(), EPS);
+		assertEquals(-1, dir.getY(), EPS);
+
+		assertEquals(0, GeomUtil.distancePointToLine(new Vector2d(0, 0), line), EPS);
+
+	}
+
+	@Test
 	void testCreateFoldLinesParallel() {
 		var s0 = new Segment(new Vector2d(-100, 100), new Vector2d(100, 100));
 		var s1 = new Segment(new Vector2d(-50, 0), new Vector2d(0, 0));


### PR DESCRIPTION
I extended the interpretation of the axiom for this case as the result line is the perpendicular bisector of the closest points between the given segments.