### PR TITLE
[Plug-in API breaking] Remove current point argument from drawing-related classes.

### DIFF
--- a/src/main/java/oripa/domain/paint/ActionState.java
+++ b/src/main/java/oripa/domain/paint/ActionState.java
@@ -1,7 +1,5 @@
 package oripa.domain.paint;
 
-import oripa.vecmath.Vector2d;
-
 /**
  * An interface for (modified) State pattern with undo. Implementation of this
  * interface should determine the state to be used after every action/undo.
@@ -16,14 +14,11 @@ public interface ActionState {
 	 *
 	 * @param context
 	 *            storage for user interaction
-	 * @param currentPoint
-	 *            Deprecated. This will be deleted in the future release.
 	 * @param differentAction
 	 *            true if action should be changed.
 	 * @return next state.
 	 */
-	ActionState doAction(PaintContext context,
-			Vector2d currentPoint, boolean differentAction);
+	ActionState doAction(PaintContext context, boolean differentAction);
 
 	/**
 	 * Performs undo of this state and returns the previous state.

--- a/src/main/java/oripa/domain/paint/addvertex/AddingVertex.java
+++ b/src/main/java/oripa/domain/paint/addvertex/AddingVertex.java
@@ -2,7 +2,6 @@ package oripa.domain.paint.addvertex;
 
 import oripa.domain.paint.PaintContext;
 import oripa.domain.paint.core.PickingVertex;
-import oripa.vecmath.Vector2d;
 
 public class AddingVertex extends PickingVertex {
 	@Override
@@ -11,10 +10,9 @@ public class AddingVertex extends PickingVertex {
 	}
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint,
-			final boolean freeSelection) {
+	protected boolean onAct(final PaintContext context, final boolean freeSelection) {
 
-		boolean result = super.onAct(context, currentPoint, true);
+		boolean result = super.onAct(context, true);
 
 		if (result == true) {
 			var lineOpt = context.getCandidateLineToPick();

--- a/src/main/java/oripa/domain/paint/bisector/SelectingVertexForBisector.java
+++ b/src/main/java/oripa/domain/paint/bisector/SelectingVertexForBisector.java
@@ -2,7 +2,6 @@ package oripa.domain.paint.bisector;
 
 import oripa.domain.paint.PaintContext;
 import oripa.domain.paint.core.PickingVertex;
-import oripa.vecmath.Vector2d;
 
 public class SelectingVertexForBisector extends PickingVertex {
 
@@ -17,9 +16,8 @@ public class SelectingVertexForBisector extends PickingVertex {
 	}
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint,
-			final boolean doSpecial) {
-		boolean vertexIsSelected = super.onAct(context, currentPoint, doSpecial);
+	protected boolean onAct(final PaintContext context, final boolean doSpecial) {
+		boolean vertexIsSelected = super.onAct(context, doSpecial);
 
 		if (!vertexIsSelected) {
 			return false;

--- a/src/main/java/oripa/domain/paint/core/AbstractActionState.java
+++ b/src/main/java/oripa/domain/paint/core/AbstractActionState.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import oripa.domain.paint.ActionState;
 import oripa.domain.paint.PaintContext;
-import oripa.vecmath.Vector2d;
 
 /**
  * a framework of (modified) State pattern with undo, which can get back to
@@ -34,8 +33,8 @@ public abstract class AbstractActionState implements ActionState {
 
 	/**
 	 * Set next state class and previous state class here. If you do nothing,
-	 * {@link #doAction(PaintContext, Vector2d, boolean)} and
-	 * {@link #undo(PaintContext)} will return {@code this} object.
+	 * {@link #doAction(PaintContext, boolean)} and {@link #undo(PaintContext)}
+	 * will return {@code this} object.
 	 */
 	protected abstract void initialize();
 
@@ -56,9 +55,9 @@ public abstract class AbstractActionState implements ActionState {
 	 */
 	@Override
 	public final ActionState doAction(final PaintContext context,
-			final Vector2d currentPoint, final boolean doSpecial) {
+			final boolean doSpecial) {
 
-		boolean success = onAct(context, currentPoint, doSpecial);
+		boolean success = onAct(context, doSpecial);
 
 		if (!success) {
 			return this;
@@ -84,15 +83,12 @@ public abstract class AbstractActionState implements ActionState {
 	 *
 	 * @param context
 	 *            storage for user interaction
-	 * @param currentPoint
-	 *            Deprecated. This will be deleted in the future release.
 	 * @param doSpecial
 	 *            true if action should be changed.
 	 * @return true if the action succeeded and should return the next state,
 	 *         otherwise false.
 	 */
-	protected abstract boolean onAct(PaintContext context,
-			Vector2d currentPoint, boolean doSpecial);
+	protected abstract boolean onAct(PaintContext context, boolean doSpecial);
 
 	/**
 	 * cancel the current actions and returns previous state.

--- a/src/main/java/oripa/domain/paint/core/PickingLine.java
+++ b/src/main/java/oripa/domain/paint/core/PickingLine.java
@@ -1,7 +1,6 @@
 package oripa.domain.paint.core;
 
 import oripa.domain.paint.PaintContext;
-import oripa.vecmath.Vector2d;
 
 /**
  * abstract class specified for picking line.
@@ -22,8 +21,7 @@ public abstract class PickingLine extends AbstractActionState {
 	 */
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint,
-			final boolean doSpecial) {
+	protected boolean onAct(final PaintContext context, final boolean doSpecial) {
 		var pickedOpt = context.getCandidateLineToPick();
 
 		pickedOpt.ifPresent(context::pushLine);

--- a/src/main/java/oripa/domain/paint/core/PickingVertex.java
+++ b/src/main/java/oripa/domain/paint/core/PickingVertex.java
@@ -1,7 +1,6 @@
 package oripa.domain.paint.core;
 
 import oripa.domain.paint.PaintContext;
-import oripa.vecmath.Vector2d;
 
 /**
  * abstract class specified for picking vertex.
@@ -21,8 +20,7 @@ public abstract class PickingVertex extends AbstractActionState {
 	 */
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint,
-			final boolean freeSelection) {
+	protected boolean onAct(final PaintContext context, final boolean freeSelection) {
 		var pickedOpt = context.getCandidateVertexToPick();
 
 		pickedOpt.ifPresent(context::pushVertex);

--- a/src/main/java/oripa/domain/paint/outline/SelectingVertexForOutline.java
+++ b/src/main/java/oripa/domain/paint/outline/SelectingVertexForOutline.java
@@ -3,7 +3,6 @@ package oripa.domain.paint.outline;
 import oripa.domain.paint.PaintContext;
 import oripa.domain.paint.core.PickingVertex;
 import oripa.util.Command;
-import oripa.vecmath.Vector2d;
 
 public class SelectingVertexForOutline extends PickingVertex {
 	private final CloseTempOutlineFactory closeTempOutlineFactory;
@@ -22,9 +21,8 @@ public class SelectingVertexForOutline extends PickingVertex {
 	}
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint,
-			final boolean freeSelection) {
-		return super.onAct(context, currentPoint, freeSelection);
+	protected boolean onAct(final PaintContext context, final boolean freeSelection) {
+		return super.onAct(context, freeSelection);
 	}
 
 	@Override

--- a/src/main/java/oripa/domain/paint/p2lp2l/SelectingSolutionLine.java
+++ b/src/main/java/oripa/domain/paint/p2lp2l/SelectingSolutionLine.java
@@ -21,7 +21,6 @@ package oripa.domain.paint.p2lp2l;
 import oripa.domain.paint.PaintContext;
 import oripa.domain.paint.core.AbstractActionState;
 import oripa.domain.paint.core.SnapPointFactory;
-import oripa.vecmath.Vector2d;
 
 /**
  * @author OUCHI Koji
@@ -37,7 +36,7 @@ public class SelectingSolutionLine extends AbstractActionState {
 	}
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint, final boolean doSpecial) {
+	protected boolean onAct(final PaintContext context, final boolean doSpecial) {
 		var solutionOpt = context.getSolutionLineToPick();
 		if (solutionOpt.isPresent()) {
 			return true;

--- a/src/main/java/oripa/domain/paint/p2ltp/SelectingSolutionLine.java
+++ b/src/main/java/oripa/domain/paint/p2ltp/SelectingSolutionLine.java
@@ -21,7 +21,6 @@ package oripa.domain.paint.p2ltp;
 import oripa.domain.paint.PaintContext;
 import oripa.domain.paint.core.AbstractActionState;
 import oripa.domain.paint.core.SnapPointFactory;
-import oripa.vecmath.Vector2d;
 
 /**
  * @author OUCHI Koji
@@ -37,7 +36,7 @@ public class SelectingSolutionLine extends AbstractActionState {
 	}
 
 	@Override
-	protected boolean onAct(final PaintContext context, final Vector2d currentPoint, final boolean doSpecial) {
+	protected boolean onAct(final PaintContext context, final boolean doSpecial) {
 		var solutionOpt = context.getSolutionLineToPick();
 		if (solutionOpt.isPresent()) {
 			return true;

--- a/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
@@ -89,8 +89,7 @@ public abstract class AbstractGraphicMouseAction implements GraphicMouseAction {
 	}
 
 	@Override
-	public void doAction(final PaintContext context, final Vector2d point,
-			final boolean differntAction) {
+	public void doAction(final PaintContext context, final boolean differntAction) {
 
 		state = state.doAction(context,
 				differntAction);

--- a/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
@@ -93,7 +93,7 @@ public abstract class AbstractGraphicMouseAction implements GraphicMouseAction {
 			final boolean differntAction) {
 
 		state = state.doAction(context,
-				point, differntAction);
+				differntAction);
 
 	}
 

--- a/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/AbstractGraphicMouseAction.java
@@ -91,8 +91,7 @@ public abstract class AbstractGraphicMouseAction implements GraphicMouseAction {
 	@Override
 	public void doAction(final PaintContext context, final boolean differntAction) {
 
-		state = state.doAction(context,
-				differntAction);
+		state = state.doAction(context, differntAction);
 
 	}
 
@@ -230,7 +229,7 @@ public abstract class AbstractGraphicMouseAction implements GraphicMouseAction {
 	}
 
 	/**
-	 * Draws the given vertex as an small rectangle.
+	 * Draws the given vertex as a small square.
 	 */
 	protected void drawVertex(final ObjectGraphicDrawer drawer, final CreasePatternViewContext viewContext,
 			final Vector2d vertex) {

--- a/src/main/java/oripa/gui/presenter/creasepattern/GraphicMouseAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/GraphicMouseAction.java
@@ -58,7 +58,7 @@ public interface GraphicMouseAction {
 
 	/**
 	 * Performs action. The default implementation calls
-	 * {@link #doAction(PaintContext, Vector2d, boolean)}.
+	 * {@link #doAction(PaintContext, boolean)}.
 	 *
 	 * @param viewContext
 	 * @param paintContext
@@ -69,9 +69,8 @@ public interface GraphicMouseAction {
 	default GraphicMouseAction onLeftClick(
 			final CreasePatternViewContext viewContext, final PaintContext paintContext,
 			final boolean differentAction) {
-		var clickPoint = viewContext.getLogicalMousePoint();
 
-		doAction(paintContext, clickPoint, differentAction);
+		doAction(paintContext, differentAction);
 		return this;
 	}
 
@@ -79,12 +78,9 @@ public interface GraphicMouseAction {
 	 * Do the action for left click.
 	 *
 	 * @param context
-	 * @param point
-	 *            the point that button is clicked at.
 	 * @param differntAction
 	 */
-	abstract void doAction(PaintContext context, Vector2d point,
-			boolean differntAction);
+	abstract void doAction(PaintContext context, boolean differntAction);
 
 	/**
 	 * Does undo action. The default implementation calls

--- a/src/main/java/oripa/gui/presenter/creasepattern/copypaste/ChangeOriginAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/copypaste/ChangeOriginAction.java
@@ -33,8 +33,7 @@ public class ChangeOriginAction extends AbstractGraphicMouseAction {
 	}
 
 	@Override
-	public void doAction(final PaintContext context, final Vector2d point,
-			final boolean differntAction) {
+	public void doAction(final PaintContext context, final boolean differntAction) {
 
 	}
 

--- a/src/main/java/oripa/gui/presenter/creasepattern/copypaste/CopyAndPasteAction.java
+++ b/src/main/java/oripa/gui/presenter/creasepattern/copypaste/CopyAndPasteAction.java
@@ -59,9 +59,8 @@ public class CopyAndPasteAction extends AbstractGraphicMouseAction {
 	}
 
 	@Override
-	public void doAction(final PaintContext context, final Vector2d point,
-			final boolean differentAction) {
-		action.doAction(context, point, differentAction);
+	public void doAction(final PaintContext context, final boolean differentAction) {
+		action.doAction(context, differentAction);
 	}
 
 	@Override

--- a/src/test/java/oripa/domain/paint/test/InputStatesTestBase.java
+++ b/src/test/java/oripa/domain/paint/test/InputStatesTestBase.java
@@ -49,13 +49,13 @@ public class InputStatesTestBase {
 	protected void doAction(final Vector2d candidate) {
 		cpLineCount = context.getCreasePattern().size();
 		context.setCandidateVertexToPick(candidate);
-		state = state.doAction(context, null, false);
+		state = state.doAction(context, false);
 	}
 
 	protected void doAction(final OriLine candidate) {
 		cpLineCount = context.getCreasePattern().size();
 		context.setCandidateLineToPick(candidate);
-		state = state.doAction(context, null, false);
+		state = state.doAction(context, false);
 
 	}
 


### PR DESCRIPTION
Current point arguments of the methods of ActionState and GraphicMouseAction are removed.
close #322