### PR TITLE
Introduce file factory.

### DIFF
--- a/src/main/java/oripa/ORIPA.java
+++ b/src/main/java/oripa/ORIPA.java
@@ -73,6 +73,7 @@ import oripa.swing.view.main.MainFrameSwingDialogFactory;
 import oripa.swing.view.main.PropertyDialogFactory;
 import oripa.swing.view.main.SubSwingFrameFactory;
 import oripa.swing.view.model.ModelViewSwingFrameFactory;
+import oripa.util.file.FileFactory;
 
 public class ORIPA {
 	public static void main(final String[] args) {
@@ -162,6 +163,8 @@ public class ORIPA {
 			var bindingFactory = new BindingObjectFactoryFacade(stateFactory, setterFactory,
 					new PluginPaintBoundStateFactory(stateManager, setterFactory));
 
+			var fileFactory = new FileFactory();
+
 			var presenter = new MainFramePresenter(
 					mainFrame,
 					viewUpdateSupport,
@@ -180,10 +183,12 @@ public class ORIPA {
 					new DefaultCutModelOutlinesHolder(),
 					presentationContext,
 					statePopperFactory,
-					new FileHistory(Constants.MRUFILE_NUM),
+					new FileHistory(Constants.MRUFILE_NUM, fileFactory),
 					new IniFileAccess(
 							new InitDataFileReader(), new InitDataFileWriter()),
-					new FileAccessService<Doc>(new FileDAO<>(new DocFileAccessSupportSelectorFactory().create())),
+					new FileAccessService<Doc>(
+							new FileDAO<>(new DocFileAccessSupportSelectorFactory().create(fileFactory), fileFactory)),
+					fileFactory,
 					plugins);
 			presenter.setViewVisible(true);
 

--- a/src/main/java/oripa/cli/CommandLineFolder.java
+++ b/src/main/java/oripa/cli/CommandLineFolder.java
@@ -34,6 +34,7 @@ import oripa.persistence.doc.DocFileAccessSupportSelectorFactory;
 import oripa.persistence.entity.FoldedModelEntity;
 import oripa.persistence.entity.exporter.FoldedModelAllExporterFOLD;
 import oripa.persistence.entity.exporter.FoldedModelSingleExporterFOLD;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -49,8 +50,9 @@ public class CommandLineFolder {
 			throw new IllegalArgumentException("Output format is not supported. acceptable format: fold");
 		}
 
+		var fileFactory = new FileFactory();
 		var creasePatternFileAccess = new FileAccessService<Doc>(
-				new FileDAO<>(new DocFileAccessSupportSelectorFactory().create()));
+				new FileDAO<>(new DocFileAccessSupportSelectorFactory().create(fileFactory), fileFactory));
 
 		try {
 			var creasePattern = creasePatternFileAccess.loadFile(inputFilePath).get().getCreasePattern();

--- a/src/main/java/oripa/cli/CreasePatternFileConverter.java
+++ b/src/main/java/oripa/cli/CreasePatternFileConverter.java
@@ -27,6 +27,7 @@ import oripa.persistence.doc.CreasePatternFileTypeKey;
 import oripa.persistence.doc.Doc;
 import oripa.persistence.doc.DocFileAccessSupportSelectorFactory;
 import oripa.persistence.doc.exporter.CreasePatternFOLDConfig;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -36,8 +37,10 @@ public class CreasePatternFileConverter {
 	private static final Logger logger = LoggerFactory.getLogger(CreasePatternFileConverter.class);
 
 	public void convert(final String inputFilePath, final String outputFilePath, final double eps) {
+		var fileFactory = new FileFactory();
+
 		var creasePatternFileAccess = new FileAccessService<Doc>(
-				new FileDAO<>(new DocFileAccessSupportSelectorFactory().create()));
+				new FileDAO<>(new DocFileAccessSupportSelectorFactory().create(fileFactory), fileFactory));
 
 		try {
 			creasePatternFileAccess.setConfigToSavingAction(CreasePatternFileTypeKey.FOLD,

--- a/src/main/java/oripa/file/FileHistory.java
+++ b/src/main/java/oripa/file/FileHistory.java
@@ -1,6 +1,5 @@
 package oripa.file;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -8,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import oripa.resource.Constants;
+import oripa.util.file.FileFactory;
 
 /**
  * for handling the most recently used files list
@@ -15,6 +15,9 @@ import oripa.resource.Constants;
  */
 public class FileHistory {
 	private LinkedList<String> mostRecentlyUsedHistory = new LinkedList<>();
+
+	private final FileFactory fileFactory;
+
 	private final int maxSize;
 
 	/**
@@ -23,8 +26,9 @@ public class FileHistory {
 	 *
 	 * @param maxSize
 	 */
-	public FileHistory(final int maxSize) {
+	public FileHistory(final int maxSize, final FileFactory fileFactory) {
 		this.maxSize = maxSize;
+		this.fileFactory = fileFactory;
 	}
 
 	/**
@@ -97,7 +101,7 @@ public class FileHistory {
 			return Constants.USER_HOME_DIR_PATH;
 		}
 
-		File file = new File(mostRecentlyUsedHistory.getFirst());
+		var file = fileFactory.create(mostRecentlyUsedHistory.getFirst());
 		try {
 			return file.getParentFile().getCanonicalPath();
 		} catch (IOException e) {

--- a/src/main/java/oripa/gui/presenter/estimation/EstimationResultFramePresenter.java
+++ b/src/main/java/oripa/gui/presenter/estimation/EstimationResultFramePresenter.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import oripa.domain.fold.FoldedModel;
 import oripa.gui.view.estimation.EstimationResultFrameView;
 import oripa.gui.view.file.FileChooserFactory;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -38,6 +39,7 @@ public class EstimationResultFramePresenter {
 	public EstimationResultFramePresenter(
 			final EstimationResultFrameView view,
 			final FileChooserFactory fileChooserFactory,
+			final FileFactory fileFactory,
 			final List<FoldedModel> foldedModels,
 			final double eps,
 			final String lastFilePath,
@@ -48,7 +50,11 @@ public class EstimationResultFramePresenter {
 
 		this.eps = eps;
 
-		var uiPresenter = new EstimationResultUIPresenter(view.getUI(), fileChooserFactory, lastFilePath,
+		var uiPresenter = new EstimationResultUIPresenter(
+				view.getUI(),
+				fileChooserFactory,
+				fileFactory,
+				lastFilePath,
 				lastFilePathChangeListener);
 
 		addListeners();

--- a/src/main/java/oripa/gui/presenter/estimation/EstimationResultUIPresenter.java
+++ b/src/main/java/oripa/gui/presenter/estimation/EstimationResultUIPresenter.java
@@ -42,6 +42,7 @@ import oripa.persistence.entity.FoldedModelFileAccessSupportSelectorFactory;
 import oripa.persistence.entity.FoldedModelFileTypeKey;
 import oripa.persistence.entity.exporter.FoldedModelPictureConfig;
 import oripa.persistence.entity.exporter.FoldedModelSVGConfig;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -54,6 +55,8 @@ public class EstimationResultUIPresenter {
 
 	final FileChooserFactory fileChooserFactory;
 
+	private final FileFactory fileFactory;
+
 	private String lastFilePath;
 	private final Consumer<String> lastFilePathChangeListener;
 
@@ -62,11 +65,14 @@ public class EstimationResultUIPresenter {
 	public EstimationResultUIPresenter(
 			final EstimationResultUIView view,
 			final FileChooserFactory fileChooserFactory,
+			final FileFactory fileFactory,
 			final String lastFilePath,
 			final Consumer<String> lastFilePathChangeListener) {
 		this.view = view;
 
 		this.fileChooserFactory = fileChooserFactory;
+
+		this.fileFactory = fileFactory;
 
 		this.lastFilePath = lastFilePath;
 		this.lastFilePathChangeListener = lastFilePathChangeListener;
@@ -89,7 +95,7 @@ public class EstimationResultUIPresenter {
 		try {
 			var supportSelectorFactory = new FoldedModelFileAccessSupportSelectorFactory();
 			var fileAccessService = new FileAccessService<FoldedModelEntity>(
-					new FileDAO<>(supportSelectorFactory.create(view.isFaceOrderFlipped())));
+					new FileDAO<>(supportSelectorFactory.create(view.isFaceOrderFlipped(), fileFactory), fileFactory));
 
 			fileAccessService.setConfigToSavingAction(
 					FoldedModelFileTypeKey.SVG_FOLDED_MODEL, this::createSVGConfig);
@@ -103,8 +109,11 @@ public class EstimationResultUIPresenter {
 
 			var entity = new FoldedModelEntity(foldedModel, view.getOverlapRelationIndex());
 
-			var presenter = new FileAccessPresenter<FoldedModelEntity>((FrameView) view.getTopLevelView(),
-					fileChooserFactory, fileAccessService);
+			var presenter = new FileAccessPresenter<FoldedModelEntity>(
+					(FrameView) view.getTopLevelView(),
+					fileChooserFactory,
+					fileFactory,
+					fileAccessService);
 
 			lastFilePath = presenter.saveUsingGUI(entity, lastFilePath).get();
 

--- a/src/main/java/oripa/gui/presenter/file/FileAccessPresenter.java
+++ b/src/main/java/oripa/gui/presenter/file/FileAccessPresenter.java
@@ -18,7 +18,6 @@
  */
 package oripa.gui.presenter.file;
 
-import java.io.File;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +31,7 @@ import oripa.gui.view.file.FileChooserFactory;
 import oripa.gui.view.file.FileFilterProperty;
 import oripa.persistence.filetool.FileAccessSupport;
 import oripa.persistence.filetool.FileTypeProperty;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -43,14 +43,17 @@ public class FileAccessPresenter<Data> {
 
 	private final FrameView parent;
 	private final FileChooserFactory chooserFactory;
+	protected final FileFactory fileFactory;
 	private final FileAccessService<Data> fileAccessService;
 
 	public FileAccessPresenter(
 			final FrameView parent,
 			final FileChooserFactory chooserFactory,
+			final FileFactory fileFactory,
 			final FileAccessService<Data> fileAccessService) {
 		this.parent = parent;
 		this.chooserFactory = chooserFactory;
+		this.fileFactory = fileFactory;
 		this.fileAccessService = fileAccessService;
 	}
 
@@ -82,7 +85,7 @@ public class FileAccessPresenter<Data> {
 		String filePath = file.getPath();
 
 		var correctedPath = correctExtension(filePath, chooser.getSelectedFilterExtensions());
-		var correctedFile = new File(correctedPath);
+		var correctedFile = fileFactory.create(correctedPath);
 
 		// TODO make a wrapper of File: exists() depends on file system and it's
 		// not testable.

--- a/src/main/java/oripa/gui/presenter/main/DocFileAccessPresenter.java
+++ b/src/main/java/oripa/gui/presenter/main/DocFileAccessPresenter.java
@@ -32,6 +32,7 @@ import oripa.gui.view.FrameView;
 import oripa.gui.view.file.FileChooserFactory;
 import oripa.persistence.doc.Doc;
 import oripa.persistence.filetool.FileTypeProperty;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -42,8 +43,9 @@ public class DocFileAccessPresenter extends FileAccessPresenter<Doc> {
 	public DocFileAccessPresenter(
 			final FrameView parent,
 			final FileChooserFactory chooserFactory,
+			final FileFactory fileFactory,
 			final FileAccessService<Doc> fileAccessService) {
-		super(parent, chooserFactory, fileAccessService);
+		super(parent, chooserFactory, fileFactory, fileAccessService);
 	}
 
 	/**
@@ -65,7 +67,7 @@ public class DocFileAccessPresenter extends FileAccessPresenter<Doc> {
 			final Supplier<Boolean> acceptModelError,
 			final double pointEps)
 			throws IOException, UserCanceledException {
-		File givenFile = new File(directory, "export." + type.getExtensions()[0]);
+		File givenFile = fileFactory.create(directory, "export." + type.getExtensions()[0]);
 		var filePath = givenFile.getCanonicalPath();
 
 		CreasePattern creasePattern = doc.getCreasePattern();

--- a/src/main/java/oripa/gui/presenter/main/MainFramePresenter.java
+++ b/src/main/java/oripa/gui/presenter/main/MainFramePresenter.java
@@ -67,6 +67,7 @@ import oripa.project.Project;
 import oripa.resource.ResourceHolder;
 import oripa.resource.ResourceKey;
 import oripa.resource.StringID;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -105,6 +106,7 @@ public class MainFramePresenter {
 	private final IniFileAccess iniFileAccess;
 	private final FileAccessService<Doc> dataFileAccess;
 	private final FileHistory fileHistory;
+	private final FileFactory fileFactory;
 
 	// services
 	private final PaintContextModification paintContextModification = new PaintContextModification();
@@ -125,6 +127,7 @@ public class MainFramePresenter {
 			final FileHistory fileHistory,
 			final IniFileAccess iniFileAccess,
 			final FileAccessService<Doc> dataFileAccess,
+			final FileFactory fileFactory,
 			final List<GraphicMouseActionPlugin> plugins) {
 		this.view = view;
 		this.dialogFactory = dialogFactory;
@@ -144,6 +147,7 @@ public class MainFramePresenter {
 		this.fileHistory = fileHistory;
 		this.iniFileAccess = iniFileAccess;
 		this.dataFileAccess = dataFileAccess;
+		this.fileFactory = fileFactory;
 
 		this.screenSetting = viewSetting.getPainterScreenSetting();
 
@@ -169,6 +173,7 @@ public class MainFramePresenter {
 				domainContext,
 				cutModelOutlinesHolder,
 				bindingFactory,
+				fileFactory,
 				screenSetting);
 
 		loadIniFile();
@@ -289,7 +294,7 @@ public class MainFramePresenter {
 
 		view.addImportButtonListener(() -> {
 			try {
-				var presenter = new DocFileAccessPresenter(view, fileChooserFactory, dataFileAccess);
+				var presenter = new DocFileAccessPresenter(view, fileChooserFactory, fileFactory, dataFileAccess);
 
 				presenter.loadUsingGUI(fileHistory.getLastPath())
 						.ifPresent(doc -> {
@@ -473,9 +478,10 @@ public class MainFramePresenter {
 
 		try {
 
-			var presenter = new DocFileAccessPresenter(view, fileChooserFactory, dataFileAccess);
+			var presenter = new DocFileAccessPresenter(view, fileChooserFactory, fileFactory, dataFileAccess);
 
-			File givenFile = new File(directory,
+			File givenFile = fileFactory.create(
+					directory,
 					(fileName.isEmpty()) ? "newFile.opx" : fileName);
 
 			var filePath = givenFile.getPath();
@@ -515,7 +521,7 @@ public class MainFramePresenter {
 	 */
 	private void saveFileWithModelCheck(final CreasePatternFileTypeKey type) {
 		try {
-			var presenter = new DocFileAccessPresenter(view, fileChooserFactory, dataFileAccess);
+			var presenter = new DocFileAccessPresenter(view, fileChooserFactory, fileFactory, dataFileAccess);
 
 			presenter.saveFileWithModelCheck(
 					new Doc(paintContext.getCreasePattern(), project.getProperty()),
@@ -567,7 +573,7 @@ public class MainFramePresenter {
 			if (filePath != null) {
 				docOpt = dataFileAccess.loadFile(filePath);
 			} else {
-				var presenter = new DocFileAccessPresenter(view, fileChooserFactory, dataFileAccess);
+				var presenter = new DocFileAccessPresenter(view, fileChooserFactory, fileFactory, dataFileAccess);
 				docOpt = presenter.loadUsingGUI(fileHistory.getLastPath());
 			}
 

--- a/src/main/java/oripa/gui/presenter/main/UIPanelPresenter.java
+++ b/src/main/java/oripa/gui/presenter/main/UIPanelPresenter.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oripa.application.FileAccessService;
 import oripa.appstate.StatePopperFactory;
 import oripa.domain.cptool.TypeForChange;
 import oripa.domain.creasepattern.CreasePattern;
@@ -56,8 +57,11 @@ import oripa.gui.view.main.SubFrameFactory;
 import oripa.gui.view.main.UIPanelView;
 import oripa.gui.view.main.ViewUpdateSupport;
 import oripa.gui.view.model.ModelViewFrameView;
+import oripa.persistence.dao.FileDAO;
+import oripa.persistence.entity.OrigamiModelFileAccessSupportSelectorFactory;
 import oripa.resource.StringID;
 import oripa.util.MathUtil;
+import oripa.util.file.FileFactory;
 import oripa.value.OriLine;
 
 /**
@@ -100,6 +104,8 @@ public class UIPanelPresenter {
 
 	private String lastResultFilePath;
 
+	private final FileFactory fileFactory;
+
 	public UIPanelPresenter(final UIPanelView view,
 			final SubFrameFactory subFrameFactory,
 			final FileChooserFactory fileChooserFactory,
@@ -109,11 +115,14 @@ public class UIPanelPresenter {
 			final PaintDomainContext domainContext,
 			final CutModelOutlinesHolder cutModelOutlinesHolder,
 			final BindingObjectFactoryFacade bindingFactory,
+			final FileFactory fileFactory,
 			final PainterScreenSetting mainScreenSetting) {
 		this.view = view;
 		this.subFrameFactory = subFrameFactory;
 
 		this.fileChooserFactory = fileChooserFactory;
+
+		this.fileFactory = fileFactory;
 
 		this.byValueContext = domainContext.getByValueContext();
 		typeForChangeContext = presentationContext.getTypeForChangeContext();
@@ -404,6 +413,10 @@ public class UIPanelPresenter {
 				origamiModels,
 				cutOutlinesHolder,
 				screenUpdater::updateScreen,
+				new FileAccessService<OrigamiModel>(
+						new FileDAO<>(new OrigamiModelFileAccessSupportSelectorFactory().create(fileFactory),
+								fileFactory)),
+				fileFactory,
 				paintContext.getPointEps());
 		modelViewPresenter.setViewVisible(true);
 
@@ -430,6 +443,7 @@ public class UIPanelPresenter {
 				var resultFramePresenter = new EstimationResultFramePresenter(
 						resultFrame,
 						fileChooserFactory,
+						fileFactory,
 						foldedModels,
 						paintContext.getPointEps(),
 						lastResultFilePath,

--- a/src/main/java/oripa/gui/presenter/model/ModelViewFramePresenter.java
+++ b/src/main/java/oripa/gui/presenter/model/ModelViewFramePresenter.java
@@ -30,9 +30,8 @@ import oripa.gui.view.main.PainterScreenSetting;
 import oripa.gui.view.model.ModelDisplayMode;
 import oripa.gui.view.model.ModelViewFrameView;
 import oripa.gui.view.util.CallbackOnUpdate;
-import oripa.persistence.dao.FileDAO;
-import oripa.persistence.entity.OrigamiModelFileAccessSupportSelectorFactory;
 import oripa.persistence.entity.OrigamiModelFileTypeKey;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -47,9 +46,8 @@ public class ModelViewFramePresenter {
 	private OrigamiModel origamiModel;
 	private final PainterScreenSetting mainScreenSetting;
 
-	private final OrigamiModelFileAccessSupportSelectorFactory supportSelectorFactory = new OrigamiModelFileAccessSupportSelectorFactory();
-	private final FileAccessService<OrigamiModel> fileAccessService = new FileAccessService<OrigamiModel>(
-			new FileDAO<>(supportSelectorFactory.create()));
+	private final FileFactory fileFactory;
+	private final FileAccessService<OrigamiModel> fileAccessService;
 
 	public ModelViewFramePresenter(
 			final ModelViewFrameView view,
@@ -58,9 +56,14 @@ public class ModelViewFramePresenter {
 			final List<OrigamiModel> origamiModels,
 			final CutModelOutlinesHolder lineHolder,
 			final CallbackOnUpdate onUpdateScissorsLine,
+			final FileAccessService<OrigamiModel> fileAccessService,
+			final FileFactory fileFactory,
 			final double eps) {
 		this.view = view;
 		this.fileChooserFactory = fileChooserFactory;
+
+		this.fileAccessService = fileAccessService;
+		this.fileFactory = fileFactory;
 
 		this.mainScreenSetting = mainScreenSetting;
 		this.origamiModels = origamiModels;
@@ -112,7 +115,7 @@ public class ModelViewFramePresenter {
 	private void exportFile(final OrigamiModelFileTypeKey type) {
 
 		try {
-			var presenter = new FileAccessPresenter<>(view, fileChooserFactory, fileAccessService);
+			var presenter = new FileAccessPresenter<>(view, fileChooserFactory, fileFactory, fileAccessService);
 
 			presenter.saveUsingGUI(origamiModel, null, List.of(type));
 		} catch (UserCanceledException e) {

--- a/src/main/java/oripa/persistence/dao/FileAccessSupportSelector.java
+++ b/src/main/java/oripa/persistence/dao/FileAccessSupportSelector.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import oripa.persistence.filetool.FileAccessSupport;
 import oripa.persistence.filetool.FileTypeProperty;
 import oripa.persistence.filetool.MultiTypeAcceptableFileLoadingSupport;
+import oripa.util.file.FileFactory;
 
 /**
  * manages available file access support objects.
@@ -40,10 +41,13 @@ import oripa.persistence.filetool.MultiTypeAcceptableFileLoadingSupport;
  */
 public class FileAccessSupportSelector<Data> {
 	private final SortedMap<FileTypeProperty<Data>, FileAccessSupport<Data>> fileAccessSupports;
+	private final FileFactory fileFactory;
 
 	public FileAccessSupportSelector(
-			final SortedMap<FileTypeProperty<Data>, FileAccessSupport<Data>> supports) {
+			final SortedMap<FileTypeProperty<Data>, FileAccessSupport<Data>> supports,
+			final FileFactory fileFactory) {
 		this.fileAccessSupports = supports;
+		this.fileFactory = fileFactory;
 	}
 
 	/**
@@ -97,7 +101,7 @@ public class FileAccessSupportSelector<Data> {
 			throw new IllegalArgumentException("Wrong path (null)");
 		}
 
-		File file = new File(path);
+		var file = fileFactory.create(path);
 		if (file.isDirectory()) {
 			throw new IllegalArgumentException("The path is for directory.");
 		}

--- a/src/main/java/oripa/persistence/dao/FileDAO.java
+++ b/src/main/java/oripa/persistence/dao/FileDAO.java
@@ -18,7 +18,6 @@
  */
 package oripa.persistence.dao;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
@@ -32,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import oripa.persistence.filetool.FileTypeProperty;
 import oripa.persistence.filetool.FileVersionError;
 import oripa.persistence.filetool.WrongDataFormatException;
+import oripa.util.file.FileFactory;
 
 /**
  * An implementation of data file access.
@@ -44,8 +44,11 @@ public class FileDAO<Data> implements DataAccessObject<Data> {
 
 	private final FileAccessSupportSelector<Data> fileAccessSupportSelector;
 
-	public FileDAO(final FileAccessSupportSelector<Data> selector) {
+	private final FileFactory fileFactory;
+
+	public FileDAO(final FileAccessSupportSelector<Data> selector, final FileFactory fileFactory) {
 		this.fileAccessSupportSelector = selector;
+		this.fileFactory = fileFactory;
 	}
 
 	public FileAccessSupportSelector<Data> getFileAccessSupportSelector() {
@@ -100,7 +103,7 @@ public class FileDAO<Data> implements DataAccessObject<Data> {
 			throws FileVersionError, IOException, FileNotFoundException, IllegalArgumentException,
 			WrongDataFormatException {
 		var canonicalPath = canonicalPath(path);
-		var file = new File(canonicalPath);
+		var file = fileFactory.create(canonicalPath);
 
 		if (!file.exists()) {
 			throw new FileNotFoundException(canonicalPath + " doesn't exist.");
@@ -145,6 +148,6 @@ public class FileDAO<Data> implements DataAccessObject<Data> {
 	}
 
 	private String canonicalPath(final String path) throws IOException {
-		return (new File(path)).getCanonicalPath();
+		return fileFactory.create(path).getCanonicalPath();
 	}
 }

--- a/src/main/java/oripa/persistence/doc/DocFileAccessSupportSelectorFactory.java
+++ b/src/main/java/oripa/persistence/doc/DocFileAccessSupportSelectorFactory.java
@@ -7,6 +7,7 @@ import oripa.persistence.dao.FileAccessSupportSelector;
 import oripa.persistence.filetool.FileAccessSupport;
 import oripa.persistence.filetool.FileTypeProperty;
 import oripa.resource.StringID;
+import oripa.util.file.FileFactory;
 
 /**
  * Creates available file access supports for {@link Doc} file access.
@@ -16,7 +17,7 @@ import oripa.resource.StringID;
  */
 public class DocFileAccessSupportSelectorFactory {
 
-	public FileAccessSupportSelector<Doc> create() {
+	public FileAccessSupportSelector<Doc> create(final FileFactory fileFactory) {
 		var supports = new TreeMap<FileTypeProperty<Doc>, FileAccessSupport<Doc>>();
 		var supportFactory = new FileAccessSupportFactory<Doc>();
 
@@ -41,6 +42,6 @@ public class DocFileAccessSupportSelectorFactory {
 		key = CreasePatternFileTypeKey.PDF;
 		supports.put(key, supportFactory.createFileAccessSupport(key, StringID.Main.FILE_ID));
 
-		return new FileAccessSupportSelector<Doc>(supports);
+		return new FileAccessSupportSelector<Doc>(supports, fileFactory);
 	}
 }

--- a/src/main/java/oripa/persistence/doc/exporter/PictureExporter.java
+++ b/src/main/java/oripa/persistence/doc/exporter/PictureExporter.java
@@ -89,7 +89,7 @@ public class PictureExporter implements DocExporter {
 		// TODO: make zeroLineWidth configurable
 		drawer.drawAllLines(objDrawer, creasePattern, scale, false);
 
-		File file = new File(filePath);
+		var file = new File(filePath);
 		ImageIO.write(image, filePath.substring(filePath.lastIndexOf(".") + 1),
 				file);
 

--- a/src/main/java/oripa/persistence/entity/FoldedModelFileAccessSupportSelectorFactory.java
+++ b/src/main/java/oripa/persistence/entity/FoldedModelFileAccessSupportSelectorFactory.java
@@ -25,6 +25,7 @@ import oripa.persistence.dao.FileAccessSupportSelector;
 import oripa.persistence.filetool.FileAccessSupport;
 import oripa.persistence.filetool.FileTypeProperty;
 import oripa.resource.StringID;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -32,7 +33,7 @@ import oripa.resource.StringID;
  */
 public class FoldedModelFileAccessSupportSelectorFactory {
 
-	public FileAccessSupportSelector<FoldedModelEntity> create(final boolean modelFlip) {
+	public FileAccessSupportSelector<FoldedModelEntity> create(final boolean modelFlip, final FileFactory fileFactory) {
 		var supports = new TreeMap<FileTypeProperty<FoldedModelEntity>, FileAccessSupport<FoldedModelEntity>>();
 		var supportFactory = new FileAccessSupportFactory<FoldedModelEntity>();
 
@@ -56,6 +57,6 @@ public class FoldedModelFileAccessSupportSelectorFactory {
 		key = FoldedModelFileTypeKey.PICTURE;
 		supports.put(key, supportFactory.createFileAccessSupport(key, StringID.ModelUI.FILE_ID));
 
-		return new FileAccessSupportSelector<FoldedModelEntity>(supports);
+		return new FileAccessSupportSelector<FoldedModelEntity>(supports, fileFactory);
 	}
 }

--- a/src/main/java/oripa/persistence/entity/OrigamiModelFileAccessSupportSelectorFactory.java
+++ b/src/main/java/oripa/persistence/entity/OrigamiModelFileAccessSupportSelectorFactory.java
@@ -26,6 +26,7 @@ import oripa.persistence.dao.FileAccessSupportSelector;
 import oripa.persistence.filetool.FileAccessSupport;
 import oripa.persistence.filetool.FileTypeProperty;
 import oripa.resource.StringID;
+import oripa.util.file.FileFactory;
 
 /**
  * @author OUCHI Koji
@@ -36,7 +37,7 @@ public class OrigamiModelFileAccessSupportSelectorFactory {
 	/**
 	 * Constructor
 	 */
-	public FileAccessSupportSelector<OrigamiModel> create() {
+	public FileAccessSupportSelector<OrigamiModel> create(final FileFactory fileFactory) {
 		var supports = new TreeMap<FileTypeProperty<OrigamiModel>, FileAccessSupport<OrigamiModel>>();
 		var supportFactory = new FileAccessSupportFactory<OrigamiModel>();
 
@@ -49,7 +50,7 @@ public class OrigamiModelFileAccessSupportSelectorFactory {
 		key = OrigamiModelFileTypeKey.SVG_MODEL;
 		supports.put(key, supportFactory.createFileAccessSupport(key, StringID.ModelUI.FILE_ID));
 
-		return new FileAccessSupportSelector<OrigamiModel>(supports);
+		return new FileAccessSupportSelector<OrigamiModel>(supports, fileFactory);
 	}
 
 }

--- a/src/main/java/oripa/renderer/estimation/FoldedModelPixelRenderer.java
+++ b/src/main/java/oripa/renderer/estimation/FoldedModelPixelRenderer.java
@@ -19,11 +19,7 @@
 package oripa.renderer.estimation;
 
 import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.io.File;
 import java.util.List;
-
-import javax.imageio.ImageIO;
 
 import oripa.domain.fold.origeom.OverlapRelation;
 import oripa.domain.fold.origeom.OverlapRelationValues;
@@ -89,8 +85,8 @@ public class FoldedModelPixelRenderer {
 	private final double minv[];
 	private final double maxv[];
 
-	private final boolean bUseTexture = false;
-	private BufferedImage textureImage = null;
+//	private final boolean bUseTexture = false;
+//	private final BufferedImage textureImage = null;
 
 	/**
 	 *
@@ -121,14 +117,14 @@ public class FoldedModelPixelRenderer {
 		minu = new double[height];
 		minv = new double[height];
 
-		if (bUseTexture) {
-			try {
-				textureImage = ImageIO.read(new File("c:\\chiyo2-1024.bmp"));
-			} catch (Exception e) {
-				e.printStackTrace();
-				textureImage = null;
-			}
-		}
+//		if (bUseTexture) {
+//			try {
+//				textureImage = ImageIO.read(new File("c:\\chiyo2-1024.bmp"));
+//			} catch (Exception e) {
+//				e.printStackTrace();
+//				textureImage = null;
+//			}
+//		}
 
 	}
 
@@ -289,21 +285,22 @@ public class FoldedModelPixelRenderer {
 						pbuf[p] = 0xffffffff;
 
 					} else {
-						if (bUseTexture) {
-							int tx = (int) (textureImage.getWidth() * u);
-							int ty = (int) (textureImage.getHeight() * v);
-
-							tx = tx % textureImage.getWidth();
-							ty = ty % textureImage.getHeight();
-							int textureColor = textureImage.getRGB(tx, ty);
-
-							if (fillFaces && (tri.isFaceFront() ^ faceOrderFlipped)) {
-								pbuf[p] = textureColor;
-							} else {
-								pbuf[p] = (tr << 16) | (tg << 8) | tb | 0xff000000;
-
-							}
-						} else {
+//						if (bUseTexture) {
+//							int tx = (int) (textureImage.getWidth() * u);
+//							int ty = (int) (textureImage.getHeight() * v);
+//
+//							tx = tx % textureImage.getWidth();
+//							ty = ty % textureImage.getHeight();
+//							int textureColor = textureImage.getRGB(tx, ty);
+//
+//							if (fillFaces && (tri.isFaceFront() ^ faceOrderFlipped)) {
+//								pbuf[p] = textureColor;
+//							} else {
+//								pbuf[p] = (tr << 16) | (tg << 8) | tb | 0xff000000;
+//
+//							}
+//						} else
+						{
 							pbuf[p] = (tr << 16) | (tg << 8) | tb | 0xff000000;
 						}
 					}

--- a/src/main/java/oripa/util/file/FileFactory.java
+++ b/src/main/java/oripa/util/file/FileFactory.java
@@ -1,0 +1,35 @@
+/**
+ * ORIPA - Origami Pattern Editor
+ * Copyright (C) 2013-     ORIPA OSS Project  https://github.com/oripa/oripa
+ * Copyright (C) 2005-2009 Jun Mitani         http://mitani.cs.tsukuba.ac.jp/
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package oripa.util.file;
+
+import java.io.File;
+
+/**
+ * @author OUCHI Koji
+ *
+ */
+public class FileFactory {
+	public File create(final String path) {
+		return new File(path);
+	}
+
+	public File create(final String directory, final String fileName) {
+		return new File(directory, fileName);
+	}
+}


### PR DESCRIPTION
To make the code more testable.
The situation has changed from the old days because recent Mockito can mock usual class's object.
I guess now we can mock java.io.File by injecting a factory of File.