### PR TITLE
Improve polygon intersection detection

### DIFF
--- a/src/main/java/oripa/domain/cptool/LineAdder.java
+++ b/src/main/java/oripa/domain/cptool/LineAdder.java
@@ -43,7 +43,7 @@ public class LineAdder {
 		var crossMap = new ConcurrentHashMap<OriPoint, OriLine>();
 
 		// could be parallelized.
-		currentLines.stream()
+		currentLines.parallelStream()
 				.forEach(line -> {
 					logger.trace("current line: {}", line);
 
@@ -184,7 +184,7 @@ public class LineAdder {
 		logger.trace("addAll() createInputLinePoints() start: {}[ms]", watch.getMilliSec());
 
 		// could be parallelized.
-		var pointLists = nonExistingNewLines.stream()
+		var pointLists = nonExistingNewLines.parallelStream()
 				.map(inputLine -> createInputLinePoints(inputLine, crossMaps.get(inputLine), pointEps))
 				.toList();
 

--- a/src/main/java/oripa/domain/cptool/LineAdder.java
+++ b/src/main/java/oripa/domain/cptool/LineAdder.java
@@ -42,6 +42,7 @@ public class LineAdder {
 
 		var crossMap = new ConcurrentHashMap<OriPoint, OriLine>();
 
+		// could be parallelized.
 		currentLines.stream()
 				.forEach(line -> {
 					logger.trace("current line: {}", line);
@@ -182,6 +183,7 @@ public class LineAdder {
 
 		logger.trace("addAll() createInputLinePoints() start: {}[ms]", watch.getMilliSec());
 
+		// could be parallelized.
 		var pointLists = nonExistingNewLines.stream()
 				.map(inputLine -> createInputLinePoints(inputLine, crossMaps.get(inputLine), pointEps))
 				.toList();

--- a/src/main/java/oripa/domain/cptool/LineAdder.java
+++ b/src/main/java/oripa/domain/cptool/LineAdder.java
@@ -42,7 +42,7 @@ public class LineAdder {
 
 		var crossMap = new ConcurrentHashMap<OriPoint, OriLine>();
 
-		currentLines.parallelStream()
+		currentLines.stream()
 				.forEach(line -> {
 					logger.trace("current line: {}", line);
 
@@ -182,7 +182,7 @@ public class LineAdder {
 
 		logger.trace("addAll() createInputLinePoints() start: {}[ms]", watch.getMilliSec());
 
-		var pointLists = nonExistingNewLines.parallelStream()
+		var pointLists = nonExistingNewLines.stream()
 				.map(inputLine -> createInputLinePoints(inputLine, crossMaps.get(inputLine), pointEps))
 				.toList();
 

--- a/src/main/java/oripa/domain/cptool/PointsMerger.java
+++ b/src/main/java/oripa/domain/cptool/PointsMerger.java
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package oripa.persistence.foldformat;
+package oripa.domain.cptool;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/oripa/domain/cptool/compgeom/SharedPointsMap.java
+++ b/src/main/java/oripa/domain/cptool/compgeom/SharedPointsMap.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import oripa.util.collection.CollectionUtil;
 import oripa.value.OriLine;
 import oripa.value.OriPoint;
+import oripa.vecmath.Vector2d;
 
 /**
  * Create this instance via {@link SharedPointsMapFactory}.
@@ -85,9 +86,14 @@ public class SharedPointsMap<P extends PointAndOriLine> extends TreeMap<OriPoint
 		if (boundMap.containsKey(p)) {
 			return p;
 		}
-		return boundMap.keySet().stream()
-				.filter(key -> key.equals(p, eps))
-				.findFirst().get();
+		var pointOpt = Vector2d.findNearest(p, boundMap.keySet());
+
+//		if (pointOpt.isEmpty()) {
+//			logger.debug("no key point in close area. trying nearest search and the result might be wrong.");
+//			return Vector2d.findNearest(p, keySet());
+//		}
+
+		return pointOpt.get();
 	}
 
 	public Optional<OriPoint> findOppositeKeyPoint(final P point, final OriPoint keyPoint,

--- a/src/main/java/oripa/domain/creasepattern/CreasePatternFactory.java
+++ b/src/main/java/oripa/domain/creasepattern/CreasePatternFactory.java
@@ -72,6 +72,10 @@ public class CreasePatternFactory {
 						.filter(OriLine::isBoundary)
 						.toList());
 
+		if (domain.isVoid()) {
+			domain = RectangleDomain.createFromSegments(lines);
+		}
+
 		// Construct CP
 		CreasePattern creasePattern = new CreasePatternImpl(domain);
 		creasePattern.addAll(lines);

--- a/src/main/java/oripa/domain/fold/AssignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/AssignedModelFolder.java
@@ -38,7 +38,7 @@ class AssignedModelFolder implements Folder {
 
 	@Override
 	public Result fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
-		simpleFolder.simpleFoldWithoutZorder(origamiModel);
+		simpleFolder.simpleFoldWithoutZorder(origamiModel, eps);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 
 		if (estimationType == EstimationType.X_RAY) {

--- a/src/main/java/oripa/domain/fold/DeterministicLayerOrderEstimator.java
+++ b/src/main/java/oripa/domain/fold/DeterministicLayerOrderEstimator.java
@@ -112,6 +112,7 @@ class DeterministicLayerOrderEstimator {
 			logger.trace("4 face cover" + System.lineSeparator() + overlapRelation.toString());
 
 			if (changed.isUnfoldable()) {
+				logger.info("unfoldable:" + System.lineSeparator() + overlapRelation.toString());
 				return changed;
 			}
 

--- a/src/main/java/oripa/domain/fold/ErrorAllowedFolder.java
+++ b/src/main/java/oripa/domain/fold/ErrorAllowedFolder.java
@@ -39,7 +39,7 @@ class ErrorAllowedFolder implements Folder {
 
 	@Override
 	public Result fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
-		simpleFolder.foldWithoutLineType(origamiModel);
+		simpleFolder.foldWithoutLineType(origamiModel, eps);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 
 		return new Result(new FoldedModel(origamiModel, List.of(), List.of()), null);

--- a/src/main/java/oripa/domain/fold/FolderFactory.java
+++ b/src/main/java/oripa/domain/fold/FolderFactory.java
@@ -18,7 +18,9 @@
  */
 package oripa.domain.fold;
 
+import oripa.domain.cptool.ElementRemover;
 import oripa.domain.cptool.LineAdder;
+import oripa.domain.cptool.PointsMerger;
 import oripa.domain.creasepattern.CreasePatternFactory;
 import oripa.domain.fold.halfedge.ModelType;
 import oripa.domain.fold.halfedge.OrigamiModel;
@@ -60,7 +62,9 @@ public class FolderFactory {
 		var subfacesFactory = new SubFacesFactory(
 				new FacesToCreasePatternConverter(
 						new CreasePatternFactory(),
-						new LineAdder()),
+						new LineAdder(),
+						new ElementRemover(),
+						new PointsMerger()),
 				new OrigamiModelFactory(),
 				new SplitFacesToSubFacesConverter(),
 				new ParentFacesCollector());
@@ -74,7 +78,9 @@ public class FolderFactory {
 		var subfacesFactory = new SubfacesOneTimeFactory(
 				new FacesToCreasePatternConverter(
 						new CreasePatternFactory(),
-						new LineAdder()),
+						new LineAdder(),
+						new ElementRemover(),
+						new PointsMerger()),
 				new OrigamiModelFactory(),
 				new SplitFacesToSubFacesConverter(),
 				new ParentFacesCollector());

--- a/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
+++ b/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
@@ -109,7 +109,7 @@ class LayerOrderEnumerator {
 
 		// construct the subfaces
 		final double paperSize = origamiModel.getPaperSize();
-		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, paperSize * eps);
+		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, paperSize * eps * 10);
 
 		logger.debug("#subface={}", subfaces.size());
 		// addKeyValue() seems not to work... See:

--- a/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
+++ b/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
@@ -109,7 +109,7 @@ class LayerOrderEnumerator {
 
 		// construct the subfaces
 		final double paperSize = origamiModel.getPaperSize();
-		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, paperSize * eps * 10);
+		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, eps);
 
 		logger.debug("#subface={}", subfaces.size());
 		// addKeyValue() seems not to work... See:

--- a/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
+++ b/src/main/java/oripa/domain/fold/LayerOrderEnumerator.java
@@ -109,7 +109,7 @@ class LayerOrderEnumerator {
 
 		// construct the subfaces
 		final double paperSize = origamiModel.getPaperSize();
-		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, eps);
+		var subfaces = subfacesFactory.createSubFaces(faces, paperSize, paperSize * eps);
 
 		logger.debug("#subface={}", subfaces.size());
 		// addKeyValue() seems not to work... See:

--- a/src/main/java/oripa/domain/fold/OverlapRelationFactory.java
+++ b/src/main/java/oripa/domain/fold/OverlapRelationFactory.java
@@ -93,6 +93,10 @@ class OverlapRelationFactory {
 				if (result == EstimationResult.UNFOLDABLE) {
 					var ret = new Result(null);
 					ret.addViolation(List.of(face, pairFace));
+					logger.debug("Overlap relation error: face{} is front={}, face{} is front={}, isM={}," +
+							" relation={}",
+							faceID, face.isFaceFront(), pairFaceID, pairFace.isFaceFront(), edge.isMountain(),
+							overlapRelation.get(faceID, pairFaceID));
 					return ret;
 				}
 			}

--- a/src/main/java/oripa/domain/fold/SimpleFolder.java
+++ b/src/main/java/oripa/domain/fold/SimpleFolder.java
@@ -89,6 +89,10 @@ class SimpleFolder {
 					.ifPresent(position -> ev.setPosition(position));
 		}
 
+		for (var face : faces) {
+			face.refreshPositions();
+		}
+
 	}
 
 	/**

--- a/src/main/java/oripa/domain/fold/SimpleFolder.java
+++ b/src/main/java/oripa/domain/fold/SimpleFolder.java
@@ -79,12 +79,12 @@ class SimpleFolder {
 
 		if (faces.size() > 0) {
 			var jobs = new LinkedList<OriFace>();
-			var paperCenter = GeomUtil.computeCentroid(
+			var paperCenterOpt = GeomUtil.computeCentroid(
 					origamiModel.getVertices().stream()
 							.map(OriVertex::getPosition)
 							.toList());
 			jobs.add(faces.stream()
-					.filter(face -> face.includesInclusively(paperCenter, eps))
+					.filter(face -> face.includesInclusively(paperCenterOpt.get(), eps))
 					.findFirst()
 					.orElse(faces.get(0)));
 			jobs.get(0).setMovedByFold(true);

--- a/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
+++ b/src/main/java/oripa/domain/fold/UnassignedModelFolder.java
@@ -40,7 +40,7 @@ class UnassignedModelFolder implements Folder {
 
 	@Override
 	public Result fold(final OrigamiModel origamiModel, final double eps, final EstimationType estimationType) {
-		simpleFolder.simpleFoldWithoutZorder(origamiModel);
+		simpleFolder.simpleFoldWithoutZorder(origamiModel, eps);
 		faceDisplayModifier.setCurrentPositionsToDisplayPositions(origamiModel);
 
 		if (estimationType == EstimationType.X_RAY) {

--- a/src/main/java/oripa/domain/fold/condfac/FaceIndicesOnHalfEdgeFactory.java
+++ b/src/main/java/oripa/domain/fold/condfac/FaceIndicesOnHalfEdgeFactory.java
@@ -18,12 +18,16 @@
  */
 package oripa.domain.fold.condfac;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.halfedge.OriHalfedge;
@@ -34,6 +38,7 @@ import oripa.domain.fold.origeom.OriGeomUtil;
  *
  */
 public class FaceIndicesOnHalfEdgeFactory {
+	private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	public Map<OriHalfedge, Set<Integer>> create(
 			final List<OriFace> faces,
@@ -59,6 +64,13 @@ public class FaceIndicesOnHalfEdgeFactory {
 				}
 			}
 		});
+
+		int count = 0;
+		for (var indexSet : indices.values()) {
+			count += indexSet.size();
+		}
+
+		logger.debug("#faceOnHalfEdge = {}", count);
 
 		return indices;
 	}

--- a/src/main/java/oripa/domain/fold/condfac/OverlappingFaceIndexIntersectionFactory.java
+++ b/src/main/java/oripa/domain/fold/condfac/OverlappingFaceIndexIntersectionFactory.java
@@ -18,9 +18,13 @@
  */
 package oripa.domain.fold.condfac;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.origeom.OverlapRelation;
@@ -30,6 +34,7 @@ import oripa.domain.fold.origeom.OverlapRelation;
  *
  */
 public class OverlappingFaceIndexIntersectionFactory {
+	private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	@SuppressWarnings("unchecked")
 	public List<Integer>[][] create(
@@ -69,6 +74,20 @@ public class OverlappingFaceIndexIntersectionFactory {
 						.toList();
 			}
 		});
+
+		int count = 0;
+		for (var intersectionLists : indexIntersections) {
+			if (intersectionLists == null) {
+				continue;
+			}
+			for (var intersections : intersectionLists) {
+				if (intersections == null) {
+					continue;
+				}
+				count += intersections.size();
+			}
+		}
+		logger.debug("#overlappingIntersection = {}", count);
 
 		return indexIntersections;
 	}

--- a/src/main/java/oripa/domain/fold/condfac/StackConditionFactoryFacade.java
+++ b/src/main/java/oripa/domain/fold/condfac/StackConditionFactoryFacade.java
@@ -61,7 +61,7 @@ public class StackConditionFactoryFacade {
 
 		var watch = new StopWatch(true);
 		subFacesOfEachFace = new FaceToSubfacesFactory().create(faces, subfaces);
-		logger.debug("create subfacesOfEeachFace {}[ms]", watch.getMilliSec());
+		logger.debug("create subfacesOfEachFace {}[ms]", watch.getMilliSec());
 
 		watch.start();
 		overlappingFaceIndexIntersections = new OverlappingFaceIndexIntersectionFactory().create(

--- a/src/main/java/oripa/domain/fold/foldability/FaceIsConvex.java
+++ b/src/main/java/oripa/domain/fold/foldability/FaceIsConvex.java
@@ -41,12 +41,12 @@ public class FaceIsConvex extends AbstractRule<OriFace> {
 		}
 
 		OriHalfedge baseHe = face.getHalfedge(0);
-		boolean baseFlg = GeomUtil.isCCW(baseHe.getPrevious().getPosition(),
+		boolean baseFlg = GeomUtil.isStrictlyCCW(baseHe.getPrevious().getPosition(),
 				baseHe.getPosition(), baseHe.getNext().getPosition());
 
 		for (int i = 1; i < face.halfedgeCount(); i++) {
 			OriHalfedge he = face.getHalfedge(i);
-			if (GeomUtil.isCCW(he.getPrevious().getPosition(), he.getPosition(),
+			if (GeomUtil.isStrictlyCCW(he.getPrevious().getPosition(), he.getPosition(),
 					he.getNext().getPosition()) != baseFlg) {
 				return false;
 			}

--- a/src/main/java/oripa/domain/fold/halfedge/OriFace.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFace.java
@@ -322,6 +322,10 @@ public class OriFace {
 		var vertices = halfedges.stream()
 				.map(OriHalfedge::getPosition).toList();
 
+		if (!isFaceFront()) {
+			vertices = vertices.reversed();
+		}
+
 		return new Polygon(removeDuplications(vertices));
 	}
 

--- a/src/main/java/oripa/domain/fold/halfedge/OriFace.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFace.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -277,10 +278,15 @@ public class OriFace {
 	}
 
 	public List<Vector2d> createOutlineVerticesBeforeFolding() {
-		Vector2d centerP = getCentroidBeforeFolding();
+		var centroidOpt = getCentroidBeforeFolding();
+
+		if (centroidOpt.isEmpty()) {
+			return List.of();
+		}
+
 		double rate = 0.5;
 		return halfedgeStream()
-				.map(he -> GeomUtil.computeDividingPoint(rate, he.getPositionBeforeFolding(), centerP))
+				.map(he -> GeomUtil.computeDividingPoint(rate, he.getPositionBeforeFolding(), centroidOpt.get()))
 				.toList();
 	}
 
@@ -289,7 +295,7 @@ public class OriFace {
 	 *
 	 * @return centroid of this face before folding
 	 */
-	public Vector2d getCentroidBeforeFolding() {
+	public Optional<Vector2d> getCentroidBeforeFolding() {
 		return GeomUtil.computeCentroid(halfedges.stream()
 				.map(OriHalfedge::getPositionBeforeFolding)
 				.toList());
@@ -301,7 +307,7 @@ public class OriFace {
 	 * @return centroid of this face with current position
 	 *         {@link OriVertex#getPosition()} of half-edges.
 	 */
-	public Vector2d getCentroid() {
+	public Optional<Vector2d> getCentroid() {
 		return GeomUtil.computeCentroid(halfedges.stream()
 				.map(OriHalfedge::getPosition)
 				.toList());

--- a/src/main/java/oripa/domain/fold/halfedge/OriFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFacesFactory.java
@@ -66,15 +66,6 @@ public class OriFacesFactory {
 
 		createdFaces = createdFaces.stream().filter(face -> face.halfedgeCount() >= 3).toList();
 
-		// remove outer face
-		var outerFaceOpt = faces.stream().filter(face -> vertices.stream()
-				.allMatch(v -> face.includesInclusively(v.getPosition(), eps)))
-				.findFirst();
-
-		if (outerFaceOpt.isPresent()) {
-			createdFaces = createdFaces.stream().filter(face -> face == outerFaceOpt.get()).toList();
-		}
-
 		var boundaryFaces = createBoundaryFaces(vertices);
 
 		// find boundary face with no internal vertex

--- a/src/main/java/oripa/domain/fold/halfedge/OriHalfedge.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriHalfedge.java
@@ -206,4 +206,10 @@ public class OriHalfedge {
 	public Vector2d getPositionBeforeFolding() {
 		return vertex.getPositionBeforeFolding();
 	}
+
+	@Override
+	public String toString() {
+		return "(from:" + getPositionBeforeFolding() + ", to:"
+				+ getNext().getPositionBeforeFolding() + ")";
+	}
 }

--- a/src/main/java/oripa/domain/fold/halfedge/OriVertex.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriVertex.java
@@ -110,6 +110,15 @@ public class OriVertex implements Comparable<OriVertex> {
 		edgeMap.put(edge.oppositeVertex(this), edge);
 	}
 
+//	public boolean canAddEdge(final OriEdge edge) {
+//		for (var e : edges) {
+//			if (MathUtil.areRadianEqual(edge.getAngle(this), e.getAngle(this))) {
+//				return false;
+//			}
+//		}
+//		return true;
+//	}
+
 	/**
 	 * Inserts the given edge as the angle list keeps in increasing order.
 	 *

--- a/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
@@ -57,8 +57,10 @@ public class OriVerticesFactory {
 			OriVertex ev = addAndGetVertexFromVVec(verticesMap, l.getOriPoint1(), pointEps);
 			OriEdge eg = new OriEdge(sv, ev, l.getType().toInt());
 			edgeCount++;
+
 			sv.addEdge(eg);
 			ev.addEdge(eg);
+
 		}
 		vertices.addAll(verticesMap.values());
 

--- a/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oripa.geom.Segment;
 import oripa.util.collection.CollectionUtil;
 import oripa.value.OriLine;
 import oripa.value.OriPoint;
@@ -43,7 +44,15 @@ public class OriVerticesFactory {
 
 		int edgeCount = 0;
 
+		var shortestSegment = new Segment(0, 0, 1e20, 0);
+
 		for (OriLine l : creasePatternWithoutAux) {
+			if (l.length() < pointEps) {
+				continue;
+			}
+
+			shortestSegment = shortestSegment.length() < l.length() ? shortestSegment : l;
+
 			OriVertex sv = addAndGetVertexFromVVec(verticesMap, l.getOriPoint0(), pointEps);
 			OriVertex ev = addAndGetVertexFromVVec(verticesMap, l.getOriPoint1(), pointEps);
 			OriEdge eg = new OriEdge(sv, ev, l.getType().toInt());
@@ -55,6 +64,7 @@ public class OriVerticesFactory {
 
 		logger.debug("#vertex = " + vertices.size());
 		logger.debug("#edge = " + edgeCount);
+		logger.debug("shortest edge ({}) = {}", shortestSegment.length(), shortestSegment);
 
 		return vertices;
 	}

--- a/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriVerticesFactory.java
@@ -30,6 +30,7 @@ import oripa.geom.Segment;
 import oripa.util.collection.CollectionUtil;
 import oripa.value.OriLine;
 import oripa.value.OriPoint;
+import oripa.vecmath.Vector2d;
 
 /**
  * @author OUCHI Koji
@@ -87,7 +88,10 @@ public class OriVerticesFactory {
 			return vtx;
 		}
 
-		return boundMap.get(neighbors.get(0));
+		// suppress position drift by using nearest
+		var neighbor = Vector2d.findNearest(p, neighbors);
+
+		return boundMap.get(neighbor.get());
 	}
 
 }

--- a/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
@@ -86,6 +86,13 @@ public class OrigamiModelFactory {
 			return origamiModel;
 		}
 
+		// remove outer face
+		logger.debug("try to remove outer face");
+		logger.debug("before: {} faces", faces.size());
+		faces.removeIf(face -> vertices.stream()
+				.allMatch(v -> face.includesInclusively(v.getPosition(), pointEps)));
+		logger.debug("after: {} faces", faces.size());
+
 		buildEdges(edges, faces);
 
 		origamiModel.setHasModel(true);

--- a/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
@@ -86,14 +86,9 @@ public class OrigamiModelFactory {
 			return origamiModel;
 		}
 
-		// remove outer face
-		logger.debug("try to remove outer face");
-		logger.debug("before: {} faces", faces.size());
-		faces.removeIf(face -> vertices.stream()
-				.allMatch(v -> face.includesInclusively(v.getPosition(), pointEps)));
-		logger.debug("after: {} faces", faces.size());
-
 		buildEdges(edges, faces);
+
+		// removeOuterFace(faces, vertices, pointEps);
 
 		origamiModel.setHasModel(true);
 

--- a/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OrigamiModelFactory.java
@@ -88,8 +88,6 @@ public class OrigamiModelFactory {
 
 		buildEdges(edges, faces);
 
-		// removeOuterFace(faces, vertices, pointEps);
-
 		origamiModel.setHasModel(true);
 
 		return origamiModel;

--- a/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
+++ b/src/main/java/oripa/domain/fold/origeom/OriGeomUtil.java
@@ -58,9 +58,9 @@ public class OriGeomUtil {
 			return true;
 		}
 
-		// If the gravity center of face0 is on face1, true
-		Vector2d center0 = face0.getCentroid();
-		if (face1.includesExclusively(center0, eps)) {
+		// If a inner point of face0 is on face1, true
+		var innerPoints0 = face0.getInnerPoints(eps);
+		if (innerPoints0.stream().anyMatch(p -> face1.includesExclusively(p, eps))) {
 			return true;
 		}
 

--- a/src/main/java/oripa/domain/fold/subface/FacesToCreasePatternConverter.java
+++ b/src/main/java/oripa/domain/fold/subface/FacesToCreasePatternConverter.java
@@ -90,8 +90,6 @@ public class FacesToCreasePatternConverter {
 //		} catch (IllegalArgumentException | IOException e) {
 //		}
 
-		// creasePattern.cleanDuplicatedLines(pointEps);
-
 		logger.debug("toCreasePattern(): {} segments", creasePattern.size());
 
 		return creasePattern;

--- a/src/main/java/oripa/domain/fold/subface/FacesToCreasePatternConverter.java
+++ b/src/main/java/oripa/domain/fold/subface/FacesToCreasePatternConverter.java
@@ -76,7 +76,7 @@ public class FacesToCreasePatternConverter {
 		// remove duplication.
 		// creasePattern.cleanDuplicatedLines(pointEps);
 
-		logger.debug("toCreasePattern(): end");
+		logger.debug("toCreasePattern(): {} segments", lines.size());
 
 		return creasePattern;
 	}

--- a/src/main/java/oripa/domain/fold/subface/ParentFacesCollector.java
+++ b/src/main/java/oripa/domain/fold/subface/ParentFacesCollector.java
@@ -29,10 +29,10 @@ import oripa.domain.fold.halfedge.OriFace;
 public class ParentFacesCollector {
 	public List<OriFace> collect(final List<OriFace> faces, final SubFace sub,
 			final double eps) {
-		var innerPoint = sub.getInnerPoint();
+		var innerPoints = sub.getInnerPoints(eps);
 
 		return faces.stream()
-				.filter(face -> face.includesExclusively(innerPoint, eps))
+				.filter(face -> innerPoints.stream().anyMatch(innerPoint -> face.includesExclusively(innerPoint, eps)))
 				.toList();
 	}
 }

--- a/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
+++ b/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
@@ -18,10 +18,16 @@
  */
 package oripa.domain.fold.subface;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import oripa.domain.fold.halfedge.OriFace;
+import oripa.domain.fold.halfedge.OriVertex;
 import oripa.domain.fold.halfedge.OrigamiModelFactory;
 
 /**
@@ -29,6 +35,8 @@ import oripa.domain.fold.halfedge.OrigamiModelFactory;
  *
  */
 public class SplitFacesToSubFacesConverter {
+	private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
 	/**
 	 *
 	 * @param splitFaces
@@ -37,10 +45,39 @@ public class SplitFacesToSubFacesConverter {
 	 *            where the parameter collection contains edges after fold.
 	 * @return
 	 */
-	public List<SubFace> convertToSubFaces(final List<OriFace> splitFaces, final double eps) {
-		return new ArrayList<SubFace>(
+	public List<SubFace> convertToSubFaces(final Collection<OriFace> splitFaces, final Collection<OriVertex> vertices,
+			final double eps) {
+		Collection<OriFace> faces = new ArrayList<>(
 				splitFaces.stream()
+						.map(face -> face.remove180degreeVertices())
+						.map(face -> face.removeDuplicatedVertices(eps))
+						.toList());
+
+		removeOuterFace(faces, vertices, eps);
+
+		return new ArrayList<SubFace>(
+				faces.stream()
 						.map(face -> new SubFace(face, eps))
 						.toList());
 	}
+
+	private void removeOuterFace(final Collection<OriFace> faces, final Collection<OriVertex> vertices,
+			final double eps) {
+
+		logger.debug("try to remove outer face");
+		logger.debug("before: {} faces", faces.size());
+
+		var outerFaceOpt = faces.stream()
+				.filter(face -> vertices.stream()
+						.allMatch(v -> face.includesInclusively(v.getPosition(), eps)))
+				.findFirst();
+		if (outerFaceOpt.isPresent()) {
+			var outerFace = outerFaceOpt.get();
+			logger.debug("remove {}", outerFace);
+			faces.removeIf(face -> face == outerFace);
+		}
+
+		logger.debug("after: {} faces", faces.size());
+	}
+
 }

--- a/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
+++ b/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
@@ -37,10 +37,10 @@ public class SplitFacesToSubFacesConverter {
 	 *            where the parameter collection contains edges after fold.
 	 * @return
 	 */
-	public List<SubFace> convertToSubFaces(final List<OriFace> splitFaces) {
+	public List<SubFace> convertToSubFaces(final List<OriFace> splitFaces, final double eps) {
 		return new ArrayList<SubFace>(
 				splitFaces.stream()
-						.map(face -> new SubFace(face))
+						.map(face -> new SubFace(face, eps))
 						.toList());
 	}
 }

--- a/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
+++ b/src/main/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverter.java
@@ -51,6 +51,7 @@ public class SplitFacesToSubFacesConverter {
 				splitFaces.stream()
 						.map(face -> face.remove180degreeVertices())
 						.map(face -> face.removeDuplicatedVertices(eps))
+						.filter(face -> face.halfedgeCount() >= 3)
 						.toList());
 
 		removeOuterFace(faces, vertices, eps);
@@ -69,7 +70,7 @@ public class SplitFacesToSubFacesConverter {
 
 		var outerFaceOpt = faces.stream()
 				.filter(face -> vertices.stream()
-						.allMatch(v -> face.includesInclusively(v.getPosition(), eps)))
+						.allMatch(v -> face.includesInclusively(v.getPosition(), eps * 5)))
 				.findFirst();
 		if (outerFaceOpt.isPresent()) {
 			var outerFace = outerFaceOpt.get();

--- a/src/main/java/oripa/domain/fold/subface/SubFace.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFace.java
@@ -34,11 +34,16 @@ import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.origeom.OverlapRelation;
 import oripa.domain.fold.stackcond.StackConditionOf3Faces;
 import oripa.domain.fold.stackcond.StackConditionOf4Faces;
+import oripa.geom.Polygon;
+import oripa.geom.TwoEarTriangulation;
 import oripa.vecmath.Vector2d;
 
 public class SubFace {
 
 	private final OriFace outline;
+
+	private final List<Polygon> outlineTriangulation;
+
 	/**
 	 * faces containing this subface.
 	 */
@@ -64,8 +69,9 @@ public class SubFace {
 	 * @param outline
 	 *            A face object describing the shape of this subface.
 	 */
-	public SubFace(final OriFace outline) {
+	public SubFace(final OriFace outline, final double eps) {
 		this.outline = outline;
+		this.outlineTriangulation = new TwoEarTriangulation().triangulate(outline.toPolygon(), eps);
 	}
 
 	/**
@@ -247,10 +253,10 @@ public class SubFace {
 
 	/**
 	 *
-	 * @return geometric center of this subface
+	 * @return inner points of subface
 	 */
-	public Vector2d getInnerPoint() {
-		return outline.getCentroid();
+	public List<Vector2d> getInnerPoints(final double eps) {
+		return outline.getInnerPoints(eps);
 	}
 
 	public OriFace getOutline() {
@@ -294,6 +300,13 @@ public class SubFace {
 		return parentFaces.size();
 	}
 
+	/**
+	 * Wrong assumption that different subfaces have different parent faces.
+	 *
+	 * @param sub
+	 * @return
+	 */
+	@Deprecated
 	public boolean isSame(final SubFace sub) {
 		if (parentFaces.size() != sub.parentFaces.size()) {
 			return false;

--- a/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
@@ -94,7 +94,7 @@ public class SubFacesFactory {
 		int i = 0;
 		for (SubFace sub : subfaces) {
 			sub.addParentFaces(parentCollector.collect(faces, sub, eps));
-			logger.debug("{} {} #parentFace={}", i++, sub.getOutline(), sub.getParentFaceCount());
+			logger.trace("{} {} #parentFace={}", i++, sub.getOutline(), sub.getParentFaceCount());
 		}
 
 		// extract distinct subfaces by comparing face list's items.

--- a/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
@@ -78,7 +78,7 @@ public class SubFacesFactory {
 			final List<OriFace> faces, final double paperSize, final double eps) {
 		logger.debug("createSubFaces() start");
 
-		var creasePattern = facesToCPConverter.convertToCreasePattern(faces, eps * 10);
+		var creasePattern = facesToCPConverter.convertToCreasePattern(faces, eps);
 
 		// By this construction, we get faces that are composed of the edges
 		// after folding where the edges are split at cross points in the crease
@@ -86,12 +86,15 @@ public class SubFacesFactory {
 		// We call such face a subface hereafter.
 		var splitFaceOrigamiModel = modelFactory.buildOrigamiForSubfaces(creasePattern, paperSize, eps);
 
-		var subfaces = facesToSubFacesConverter.convertToSubFaces(splitFaceOrigamiModel.getFaces(), eps);
+		var subfaces = facesToSubFacesConverter.convertToSubFaces(
+				splitFaceOrigamiModel.getFaces(), splitFaceOrigamiModel.getVertices(), eps);
 
 		// Stores the face reference of given crease pattern into the subface
 		// that is contained in the face.
+		int i = 0;
 		for (SubFace sub : subfaces) {
 			sub.addParentFaces(parentCollector.collect(faces, sub, eps));
+			logger.debug("{} {} #parentFace={}", i++, sub.getOutline(), sub.getParentFaceCount());
 		}
 
 		// extract distinct subfaces by comparing face list's items.

--- a/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
@@ -18,7 +18,6 @@
  */
 package oripa.domain.fold.subface;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -87,25 +86,26 @@ public class SubFacesFactory {
 		// We call such face a subface hereafter.
 		var splitFaceOrigamiModel = modelFactory.buildOrigamiForSubfaces(creasePattern, paperSize, eps);
 
-		var subFaces = facesToSubFacesConverter.convertToSubFaces(splitFaceOrigamiModel.getFaces());
+		var subfaces = facesToSubFacesConverter.convertToSubFaces(splitFaceOrigamiModel.getFaces(), eps);
 
 		// Stores the face reference of given crease pattern into the subface
 		// that is contained in the face.
-		for (SubFace sub : subFaces) {
+		for (SubFace sub : subfaces) {
 			sub.addParentFaces(parentCollector.collect(faces, sub, eps));
 		}
 
 		// extract distinct subfaces by comparing face list's items.
-		ArrayList<SubFace> distinctSubFaces = new ArrayList<>();
-		for (SubFace sub : subFaces) {
-			if (distinctSubFaces.stream()
-					.noneMatch(sub::isSame)) {
-				distinctSubFaces.add(sub);
-			}
-		}
+		// -> this logic is not necessary because subface is maximal.
+//		ArrayList<SubFace> distinctSubFaces = new ArrayList<>();
+//		for (SubFace sub : subFaces) {
+//			if (distinctSubFaces.stream()
+//					.noneMatch(sub::isSame)) {
+//				distinctSubFaces.add(sub);
+//			}
+//		}
 
-		logger.debug("createSubFaces() end");
+		logger.debug("createSubFaces() end: {} subfaces", subfaces.size());
 
-		return distinctSubFaces;
+		return subfaces;
 	}
 }

--- a/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFacesFactory.java
@@ -78,7 +78,7 @@ public class SubFacesFactory {
 			final List<OriFace> faces, final double paperSize, final double eps) {
 		logger.debug("createSubFaces() start");
 
-		var creasePattern = facesToCPConverter.convertToCreasePattern(faces, eps);
+		var creasePattern = facesToCPConverter.convertToCreasePattern(faces, eps * 10);
 
 		// By this construction, we get faces that are composed of the edges
 		// after folding where the edges are split at cross points in the crease

--- a/src/main/java/oripa/geom/GeomUtil.java
+++ b/src/main/java/oripa/geom/GeomUtil.java
@@ -528,8 +528,12 @@ public class GeomUtil {
 	 * @return true if vector p0 -> q ends in left side of p0 -> p1 (q is at
 	 *         counterclockwise position) otherwise false.
 	 */
-	public static boolean isCCW(final Vector2d p0, final Vector2d p1, final Vector2d q) {
+	public static boolean isStrictlyCCW(final Vector2d p0, final Vector2d p1, final Vector2d q) {
 		return CCWcheck(p0, p1, q, 0) == 1;
+	}
+
+	public static boolean isCCW(final Vector2d p0, final Vector2d p1, final Vector2d q) {
+		return CCWcheck(p0, p1, q, 0) >= 0;
 	}
 
 	public static int CCWcheck(final Vector2d p0, final Vector2d p1, final Vector2d q) {
@@ -556,18 +560,12 @@ public class GeomUtil {
 	}
 
 	private static double computeCCW(final Vector2d p0, final Vector2d p1, final Vector2d q) {
-		double dx1, dx2, dy1, dy2;
 
 		var d1 = p1.subtract(p0).normalize();
 
 		var d2 = q.subtract(p0).normalize();
 
-		dx1 = d1.getX();
-		dy1 = d1.getY();
-		dx2 = d2.getX();
-		dy2 = d2.getY();
-
-		return dx1 * dy2 - dy1 * dx2;
+		return d1.crossProductZ(d2);
 	}
 
 	public static Vector2d computeCentroid(final Collection<Vector2d> points) {

--- a/src/main/java/oripa/geom/GeomUtil.java
+++ b/src/main/java/oripa/geom/GeomUtil.java
@@ -137,14 +137,19 @@ public class GeomUtil {
 	 */
 	public static Segment getVerticalSegment(final Vector2d v, final Segment segment) {
 
-		var p0 = segment.getP0();
-		var p1 = segment.getP1();
+		var sp = segment.getP0();
+		var ep = segment.getP1();
 
-		var sub = p1.subtract(p0);
+		var ds = v.distance(sp);
+		var de = v.distance(ep);
+		var sp_ = ds > de ? sp : ep;
+		var ep_ = ds > de ? ep : sp;
 
-		double t = computeParameterForNearestPointToLine(v, p0, p1);
+		var dir = ep_.subtract(sp_).normalize();
 
-		var cp = p0.add(sub.multiply(t));
+		double t = computeParameterForNearestPointToLine(v, sp_, dir);
+
+		var cp = sp_.add(dir.multiply(t));
 
 		return new Segment(cp, v);
 	}
@@ -213,7 +218,12 @@ public class GeomUtil {
 	 */
 	public static Vector2d getSymmetricPoint(final Vector2d p, final Vector2d sp,
 			final Vector2d ep) {
-		Vector2d cp = getNearestPointToLine(p, sp, ep);
+		var ds = p.distance(sp);
+		var de = p.distance(ep);
+		var sp_ = ds > de ? sp : ep;
+		var ep_ = ds > de ? ep : sp;
+
+		Vector2d cp = getNearestPointToLine(p, sp_, ep_);
 		return cp.multiply(2).subtract(p);
 	}
 
@@ -317,37 +327,44 @@ public class GeomUtil {
 	}
 
 	/**
+	 * p and sp should be far enough because they will be used in subtraction.
 	 *
 	 * @param p
 	 *            point
 	 * @param sp
 	 *            start point of line vector
-	 * @param ep
-	 *            end point of line vector
-	 * @return t = |p - sp| * cos(\theta) / |ep - sp| where theta is the angle
-	 *         between p - sp and ep - sp
+	 * @param unitLineDir
+	 *            unit line vector = (ep - sp).normalize()
+	 * @return t = |p - sp| * cos(\theta) where theta is the angle between p -
+	 *         sp and unitLineVector
 	 */
 	private static double computeParameterForNearestPointToLine(
-			final Vector2d p, final Vector2d sp, final Vector2d ep) {
+			final Vector2d p, final Vector2d sp, final Vector2d unitLineDir) {
 
 		var sub0 = p.subtract(sp);
 
-		// direction of the line
-		var dir = ep.subtract(sp);
+		// forcing to use normalize() is good becouse it does no arithmetics,
+		// which should be robust.
 
-		// t = |sub0| * cos(\theta) / |dir|
-		return dir.dot(sub0) / dir.lengthSquared();
+		// direction of the line
+		// t = |sub0| * cos(\theta) / |dir| = |sub0|*cos(\theta)
+		return unitLineDir.dot(sub0);
 	}
 
 	private static Vector2d getNearestPointToLine(
 			final Vector2d p, final Vector2d sp, final Vector2d ep) {
 
+		var ds = p.distance(sp);
+		var de = p.distance(ep);
+		var sp_ = ds > de ? sp : ep;
+		var ep_ = ds > de ? ep : sp;
+
 		// direction of the line
-		var dir = ep.subtract(sp);
+		var dir = ep_.subtract(sp_).normalize();
 
-		double t = computeParameterForNearestPointToLine(p, sp, ep);
+		double t = computeParameterForNearestPointToLine(p, sp_, dir);
 
-		return sp.add(dir.multiply(t));
+		return sp_.add(dir.multiply(t));
 	}
 
 	public static double distancePointToSegment(final Vector2d p, final Segment segment) {
@@ -373,17 +390,24 @@ public class GeomUtil {
 
 		var sp = segment.getP0();
 		var ep = segment.getP1();
+		var length = segment.length();
 
-		double t = computeParameterForNearestPointToLine(p, sp, ep);
+		var ds = p.distance(sp);
+		var de = p.distance(ep);
+		var sp_ = ds > de ? sp : ep;
+		var ep_ = ds > de ? ep : sp;
+
+		// direction of the line
+		var dir = ep_.subtract(sp_).normalize();
+
+		double t = computeParameterForNearestPointToLine(p, sp_, dir);
 
 		if (t <= 0.0) {
-			return sp;
-		} else if (t >= 1.0) {
-			return ep;
+			return sp_;
+		} else if (t >= length) {
+			return ep_;
 		} else {
-			// direction of the line
-			var dir = ep.subtract(sp);
-			return sp.add(dir.multiply(t));
+			return sp_.add(dir.multiply(t));
 		}
 	}
 
@@ -391,7 +415,12 @@ public class GeomUtil {
 		var sp = line.getPoint();
 		var ep = sp.add(line.getDirection());
 
-		return p.distance(getNearestPointToLine(p, sp, ep));
+		var ds = p.distance(sp);
+		var de = p.distance(ep);
+		var sp_ = ds > de ? sp : ep;
+		var ep_ = ds > de ? ep : sp;
+
+		return p.distance(getNearestPointToLine(p, sp_, ep_));
 	}
 
 	public static double distancePointToRay(final Vector2d p, final Ray ray) {
@@ -401,9 +430,8 @@ public class GeomUtil {
 	public static Vector2d getNearestPointToRay(final Vector2d p, final Ray ray) {
 		var sp = ray.getEndPoint();
 		var dir = ray.getDirection();
-		var ep = sp.add(dir);
 
-		double t = computeParameterForNearestPointToLine(p, sp, ep);
+		double t = computeParameterForNearestPointToLine(p, sp, dir);
 
 		if (t <= 0.0) {
 			return sp;
@@ -518,9 +546,8 @@ public class GeomUtil {
 	public static double distance(final Vector2d p, final Line line, final double[] param) {
 
 		var sp = line.getPoint();
-		var ep = sp.add(line.getDirection());
 
-		param[0] = computeParameterForNearestPointToLine(p, sp, ep);
+		param[0] = computeParameterForNearestPointToLine(p, sp, line.getDirection());
 		return distancePointToLine(p, line);
 	}
 

--- a/src/main/java/oripa/geom/GeomUtil.java
+++ b/src/main/java/oripa/geom/GeomUtil.java
@@ -568,11 +568,15 @@ public class GeomUtil {
 		return d1.crossProductZ(d2);
 	}
 
-	public static Vector2d computeCentroid(final Collection<Vector2d> points) {
+	public static Optional<Vector2d> computeCentroid(final Collection<Vector2d> points) {
 
-		var sum = points.stream()
-				.reduce((result, x) -> result.add(x))
-				.get();
-		return sum.multiply(1.0 / points.size());
+		if (points.isEmpty()) {
+			return Optional.empty();
+		}
+
+		var sumOpt = points.stream()
+				.reduce((result, x) -> result.add(x));
+
+		return sumOpt.map(sum -> sum.multiply(1.0 / points.size()));
 	}
 }

--- a/src/main/java/oripa/geom/Polygon.java
+++ b/src/main/java/oripa/geom/Polygon.java
@@ -1,0 +1,206 @@
+/**
+ * ORIPA - Origami Pattern Editor
+ * Copyright (C) 2013-     ORIPA OSS Project  https://github.com/oripa/oripa
+ * Copyright (C) 2005-2009 Jun Mitani         http://mitani.cs.tsukuba.ac.jp/
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package oripa.geom;
+
+import java.util.List;
+
+import oripa.vecmath.Vector2d;
+
+/**
+ * @author OUCHI Koji
+ *
+ */
+public class Polygon {
+	private final List<Vector2d> vertices;
+	private final Vector2d centroid;
+
+	private List<Polygon> triangles;
+
+	public Polygon(final List<Vector2d> vertices) {
+		this.vertices = List.copyOf(vertices);
+		centroid = GeomUtil.computeCentroid(vertices);
+	}
+
+	public Polygon(final Polygon polygon) {
+		this(polygon.vertices);
+	}
+
+	public Vector2d getVertex(final int i) {
+		return vertices.get(i);
+	}
+
+	public int verticesCount() {
+		return vertices.size();
+	}
+
+	public Segment getEdge(final int i) {
+		return new Segment(vertices.get(i), vertices.get((i + 1) % verticesCount()));
+	}
+
+	public Polygon removeVertex(final int i) {
+		var vertex = vertices.get(i);
+		return new Polygon(vertices.stream().filter(v -> v != vertex).toList());
+	}
+
+	/**
+	 *
+	 * @return centroid of this polygon.
+	 */
+	public Vector2d getCentroid() {
+		return centroid;
+	}
+
+	/**
+	 *
+	 * @return inner points of subface
+	 */
+	public List<Vector2d> getInnerPoints(final double eps) {
+		buildTriangles(eps);
+		return triangles.stream().map(Polygon::getCentroid).toList();
+	}
+
+	/**
+	 * Whether v is inclusively on this polygon (inside or on the edges).
+	 * Assumes this polygon is convex.
+	 *
+	 * @param v
+	 *            point to be tested.
+	 * @return true if v is inside or on the edges of this face.
+	 */
+	public boolean includesInclusively(final Vector2d v, final double eps) {
+		// If it's on the face's edge, return true
+		if (isOnEdge(v, eps)) {
+			return true;
+		}
+
+		return isInside(v, eps);
+	}
+
+	/**
+	 * Whether v is strictly inside of this polygon. Assumes this polygon is
+	 * convex.
+	 *
+	 * @param v
+	 *            point to be tested.
+	 * @return true if v is strictly inside of this face.
+	 */
+	public boolean includesExclusively(final Vector2d v, final double eps) {
+		// If it's on the face's edge, return false
+		if (isOnEdge(v, eps)) {
+			return false;
+		}
+
+		return isInside(v, eps);
+	}
+
+	/**
+	 * Whether v is on edge of polygon.
+	 *
+	 * @param v
+	 *            point to be tested.
+	 * @param eps
+	 * @param getPosition
+	 *            a function to get the position of face's vertex from
+	 *            half-edge. That is, you can designate using position before
+	 *            fold or the one after fold.
+	 * @return
+	 */
+	private boolean isOnEdge(final Vector2d v, final double eps) {
+		int n = verticesCount();
+		// If it's on the polygon's edge, return true
+		for (int i = 0; i < n; i++) {
+			if (GeomUtil.distancePointToSegment(v, vertices.get(i),
+					vertices.get((i + 1) % n)) < eps) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isInside(final Vector2d v, final double eps) {
+		buildTriangles(eps);
+
+		return triangles.stream().anyMatch(triangle -> triangle.isInsideConvex(v));
+	}
+
+	private void buildTriangles(final double eps) {
+		if (triangles == null) {
+			var triangulator = new TwoEarTriangulation();
+
+			triangles = triangulator.triangulate(this, eps);
+
+			if (triangles.isEmpty()) {
+				triangles = triangulator.triangulate(new Polygon(vertices.reversed()), eps);
+			}
+
+			if (triangles.isEmpty()) {
+				throw new IllegalStateException("Failed to triangulate a polygon.");
+			}
+		}
+
+	}
+
+	/**
+	 * Whether v is inside of this polygon. This method is very sensitive to the
+	 * case that v is very close to the edge. Assumes this polygon is convex.
+	 *
+	 * @param v
+	 *            point to be tested.
+	 * @param getPosition
+	 *            a function to get the position of face's vertex from
+	 *            half-edge. That is, you can designate using position before
+	 *            fold or the one after fold.
+	 * @return true if v inside of this face.
+	 */
+	private boolean isInsideConvex(final Vector2d v) {
+		int n = verticesCount();
+
+		var baseEdge = getEdge(0);
+		boolean baseFlg = GeomUtil.isStrictlyCCW(baseEdge.getP0(),
+				baseEdge.getP1(), v);
+
+		for (int i = 1; i < n; i++) {
+			var he = getEdge(i);
+			if (GeomUtil.isStrictlyCCW(he.getP0(), he.getP1(),
+					v) != baseFlg) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether this face includes {@code line} entirely. The inclusion test is
+	 * inclusive. Assumes this polygon is convex.
+	 *
+	 * @param segment
+	 * @return {@code true} if {@code face} includes {@code line} entirely.
+	 */
+	public boolean includesInclusively(final Segment segment, final double eps) {
+		return includesInclusively(segment.getP0(), eps)
+				&& includesInclusively(segment.getP1(), eps);
+	}
+
+	@Override
+	public String toString() {
+		return vertices.toString();
+	}
+
+}

--- a/src/main/java/oripa/geom/Polygon.java
+++ b/src/main/java/oripa/geom/Polygon.java
@@ -35,7 +35,7 @@ public class Polygon {
 	public Polygon(final List<Vector2d> vertices) {
 		this.vertices = List.copyOf(vertices);
 
-		centroid = GeomUtil.computeCentroid(vertices);
+		centroid = GeomUtil.computeCentroid(vertices).orElse(null);
 	}
 
 	public Polygon(final Polygon polygon) {
@@ -61,7 +61,7 @@ public class Polygon {
 
 	/**
 	 *
-	 * @return centroid of this polygon.
+	 * @return centroid of this polygon. can be null.
 	 */
 	public Vector2d getCentroid() {
 		return centroid;
@@ -72,6 +72,9 @@ public class Polygon {
 	 * @return inner points of subface
 	 */
 	public List<Vector2d> getInnerPoints(final double eps) {
+		if (verticesCount() < 3) {
+			return List.of();
+		}
 		buildTriangles(eps);
 		return triangles.stream().map(Polygon::getCentroid).toList();
 	}
@@ -137,7 +140,7 @@ public class Polygon {
 	private boolean isInside(final Vector2d v, final double eps) {
 		buildTriangles(eps);
 
-		return triangles.stream().anyMatch(triangle -> triangle.isInsideConvex(v));
+		return triangles.stream().anyMatch(triangle -> triangle.isOnEdge(v, eps) || triangle.isInsideConvex(v));
 	}
 
 	private void buildTriangles(final double eps) {

--- a/src/main/java/oripa/geom/Polygon.java
+++ b/src/main/java/oripa/geom/Polygon.java
@@ -34,6 +34,7 @@ public class Polygon {
 
 	public Polygon(final List<Vector2d> vertices) {
 		this.vertices = List.copyOf(vertices);
+
 		centroid = GeomUtil.computeCentroid(vertices);
 	}
 

--- a/src/main/java/oripa/geom/TwoEarTriangulation.java
+++ b/src/main/java/oripa/geom/TwoEarTriangulation.java
@@ -81,7 +81,7 @@ public class TwoEarTriangulation {
 		}
 
 		if (p.verticesCount() != 3) {
-			logger.trace("failed: fewer cuts " + polygon.verticesCount()
+			logger.debug("failed: fewer cuts " + polygon.verticesCount()
 					+ "->" + p.verticesCount() + System.lineSeparator()
 					+ " polygon:" + polygon + System.lineSeparator()
 					+ " remain:" + p + System.lineSeparator()

--- a/src/main/java/oripa/geom/TwoEarTriangulation.java
+++ b/src/main/java/oripa/geom/TwoEarTriangulation.java
@@ -20,10 +20,14 @@ package oripa.geom;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import oripa.vecmath.Vector2d;
 
 /**
  * Does triangulation according to two-ear theorem.
@@ -34,6 +38,181 @@ import org.slf4j.LoggerFactory;
 public class TwoEarTriangulation {
 	private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+	private class Vertex {
+		Vector2d v;
+		int originalIndex;
+		int prevIndexOnP;
+		int nextIndexOnP;
+
+		Vertex(final Vector2d v, final int originalIndex, final int prevIndexOnP, final int nextIndexOnP) {
+			this.v = v;
+			this.originalIndex = originalIndex;
+			this.prevIndexOnP = prevIndexOnP;
+			this.nextIndexOnP = nextIndexOnP;
+		}
+
+		@Override
+		public String toString() {
+			return "" + v + " original:" + originalIndex + " prevP:" + prevIndexOnP + " nextP:" + nextIndexOnP;
+		}
+	}
+
+	public List<Polygon> triangulate(final Polygon polygon, final double eps) {
+		int n = polygon.verticesCount();
+
+		var triangles = new ArrayList<Polygon>();
+		var pIndices = new ArrayList<Integer>();
+		var p = new ArrayList<Vertex>();
+
+		var isConvex = new Boolean[n];
+		var convexes = new LinkedList<Vertex>();
+		Arrays.fill(isConvex, false);
+
+		if (n == 3) {
+			triangles.add(polygon);
+			return triangles;
+		}
+
+		for (int i = 0; i < n; i++) {
+			int i0 = (i - 1 + n) % n;
+			int i1 = i;
+			int i2 = (i + 1) % n;
+
+			var v0 = polygon.getVertex(i0);
+			var v1 = polygon.getVertex(i1);
+			var v2 = polygon.getVertex(i2);
+
+			var vertex = new Vertex(v1, i1, i0, i2);
+			p.add(vertex);
+
+			// center angle should not be larger than or equal to 180
+			// degrees.
+			if (GeomUtil.isStrictlyCCW(v0, v1, v2)) {
+				isConvex[i1] = true;
+				convexes.add(vertex);
+			}
+			pIndices.add(i0);
+		}
+
+		int count = 0;
+		while (!convexes.isEmpty() && count < n) {
+			count++;
+			logger.trace("p: " + p);
+			logger.trace("convexes: " + convexes);
+			logger.trace("triangles: " + triangles);
+
+			var vertex1 = convexes.removeFirst();
+			var vertex0 = p.get(vertex1.prevIndexOnP);
+			var vertex2 = p.get(vertex1.nextIndexOnP);
+
+			if (vertex1.prevIndexOnP == vertex1.nextIndexOnP) {
+				break;
+			}
+
+			var e0 = new Segment(vertex0.v, vertex1.v);
+			var e1 = new Segment(vertex1.v, vertex2.v);
+			var e = new Segment(vertex0.v, vertex2.v);
+
+			if (!crossesPolygonEdge(p, e0, e1, e, vertex1.prevIndexOnP, eps)) {
+
+				var triangle = new Polygon(List.of(vertex0.v, vertex1.v, vertex2.v));
+				triangles.add(triangle);
+
+				// remove vertex1
+				vertex0.nextIndexOnP = vertex1.nextIndexOnP;
+				vertex2.prevIndexOnP = vertex1.prevIndexOnP;
+
+				// test vertex0
+				int i0 = vertex1.prevIndexOnP;
+				var vertexPrev0 = p.get(vertex0.prevIndexOnP);
+				if (!isConvex[i0] && GeomUtil.isStrictlyCCW(vertexPrev0.v, vertex0.v, vertex1.v)) {
+					isConvex[i0] = true;
+					convexes.add(vertex0);
+				}
+
+				// test vertex2
+				int i2 = vertex1.nextIndexOnP;
+				var vertexNext2 = p.get(vertex2.nextIndexOnP);
+				if (!isConvex[i2] && GeomUtil.isStrictlyCCW(vertex1.v, vertex2.v, vertexNext2.v)) {
+					isConvex[i2] = true;
+					convexes.add(vertex2);
+				}
+
+			} else {
+				convexes.addLast(vertex1);
+			}
+
+		}
+
+		if (triangles.size() != polygon.verticesCount() - 2) {
+			logger.debug("failed: fewer triangles, #triangle should be " + (polygon.verticesCount() - 2)
+					+ " but is " + triangles.size() + System.lineSeparator()
+					+ " polygon:" + polygon + System.lineSeparator()
+					+ " triangles:" + triangles);
+			return List.of();
+		}
+
+		return triangles;
+	}
+
+	private boolean crossesPolygonEdge(final List<Vertex> p,
+			final Segment e0, final Segment e1, final Segment e,
+			final int i0,
+			final double eps) {
+
+		if (GeomUtil.isOverlap(e0, e1, eps)) {
+			return false;
+		}
+
+		var vertex0 = p.get(i0);
+		var vertex1 = p.get(vertex0.nextIndexOnP);
+		int i1 = vertex0.nextIndexOnP;
+		int i2 = vertex1.nextIndexOnP;
+
+		// triangle
+		if (i0 == p.get(i2).nextIndexOnP) {
+			return false;
+		}
+
+		var j = -1;
+
+		while (j != i0) {
+
+			if (vertex0.nextIndexOnP == i1 || vertex0.nextIndexOnP == i2) {
+				j = vertex0.nextIndexOnP;
+				vertex0 = vertex1;
+				vertex1 = p.get(vertex1.nextIndexOnP);
+				continue;
+			}
+
+			var e_j = new Segment(vertex0.v, vertex1.v);
+
+			if (e.equals(e_j, eps)) {
+				return true;
+			}
+
+			var crossOpt = GeomUtil.getCrossPoint(e, e_j);
+			// crosses
+			if (crossOpt.isPresent()) {
+				// cross point is the endpoint of e
+				if (crossOpt.filter(cross -> e.pointStream().anyMatch(v -> v.equals(cross, eps))).isPresent()) {
+					// cross point is the angle of the triangle
+					j = vertex0.nextIndexOnP;
+					vertex0 = vertex1;
+					vertex1 = p.get(vertex1.nextIndexOnP);
+					continue;
+				}
+				return true;
+			} else if (GeomUtil.isOverlap(e, e_j, eps)) {
+				return true;
+			}
+			j = vertex0.nextIndexOnP;
+			vertex0 = vertex1;
+			vertex1 = p.get(vertex1.nextIndexOnP);
+		}
+		return false;
+	}
+
 	/**
 	 * returns list of triangles. empty if failed.
 	 *
@@ -41,7 +220,7 @@ public class TwoEarTriangulation {
 	 * @param eps
 	 * @return
 	 */
-	public List<Polygon> triangulate(final Polygon polygon, final double eps) {
+	public List<Polygon> triangulateNaive(final Polygon polygon, final double eps) {
 
 		var triangles = new ArrayList<Polygon>();
 
@@ -75,7 +254,7 @@ public class TwoEarTriangulation {
 							+ triangles.size() + " triangles:" + triangles);
 					continue;
 				}
-				if (!crossesPolygonEdge(p, e0, e1, e, i0, i1, i2, eps)) {
+				if (!crossesPolygonEdgeNaive(p, e0, e1, e, i0, i1, i2, eps)) {
 					p = p.removeVertex(i1);
 					var triangle = new Polygon(List.of(v0, v1, v2));
 					triangles.add(triangle);
@@ -108,7 +287,7 @@ public class TwoEarTriangulation {
 		return triangles;
 	}
 
-	private boolean crossesPolygonEdge(final Polygon p,
+	private boolean crossesPolygonEdgeNaive(final Polygon p,
 			final Segment e0, final Segment e1, final Segment e,
 			final int i0, final int i1, final int i2,
 			final double eps) {

--- a/src/main/java/oripa/geom/TwoEarTriangulation.java
+++ b/src/main/java/oripa/geom/TwoEarTriangulation.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Does triangulation according to two-ear theorem.
+ *
  * @author OUCHI Koji
  *
  */
@@ -84,7 +86,7 @@ public class TwoEarTriangulation {
 		}
 
 		if (p.verticesCount() != 3) {
-			logger.debug("failed: fewer cuts " + polygon.verticesCount()
+			logger.trace("failed: fewer cuts " + polygon.verticesCount()
 					+ "->" + p.verticesCount() + System.lineSeparator()
 					+ " polygon:" + polygon + System.lineSeparator()
 					+ " remain:" + p + System.lineSeparator()
@@ -95,7 +97,7 @@ public class TwoEarTriangulation {
 		triangles.add(p);
 
 		if (triangles.size() != polygon.verticesCount() - 2) {
-			logger.debug("faild: fewer triangles, #triangle should be " + (polygon.verticesCount() - 2)
+			logger.trace("failed: fewer triangles, #triangle should be " + (polygon.verticesCount() - 2)
 					+ " but is " + triangles.size() + System.lineSeparator()
 					+ " polygon:" + polygon + System.lineSeparator()
 					+ " remain:" + p + System.lineSeparator()

--- a/src/main/java/oripa/geom/TwoEarTriangulation.java
+++ b/src/main/java/oripa/geom/TwoEarTriangulation.java
@@ -60,6 +60,10 @@ public class TwoEarTriangulation {
 				var v1 = p.getVertex(i1);
 				var v2 = p.getVertex(i2);
 
+				var e0 = new Segment(v0, v1);
+				var e1 = new Segment(v1, v2);
+				var e = new Segment(v0, v2);
+
 				// center angle should not be larger than or equal to 180
 				// degrees.
 				if (!GeomUtil.isStrictlyCCW(v0, v1, v2)) {
@@ -69,8 +73,7 @@ public class TwoEarTriangulation {
 							+ triangles.size() + " triangles:" + triangles);
 					continue;
 				}
-				var e = new Segment(v0, v2);
-				if (!crossesPolygonEdge(e, p, i0, i1, eps)) {
+				if (!crossesPolygonEdge(p, e0, e1, e, i0, i1, i2, eps)) {
 					p = p.removeVertex(i1);
 					var triangle = new Polygon(List.of(v0, v1, v2));
 					triangles.add(triangle);
@@ -92,14 +95,30 @@ public class TwoEarTriangulation {
 		triangles.add(p);
 
 		if (triangles.size() != polygon.verticesCount() - 2) {
-			throw new AssertionError("Wrong implementation!: #triangle should be " + (polygon.verticesCount() - 2)
-					+ " but is " + triangles.size());
+			logger.debug("faild: fewer triangles, #triangle should be " + (polygon.verticesCount() - 2)
+					+ " but is " + triangles.size() + System.lineSeparator()
+					+ " polygon:" + polygon + System.lineSeparator()
+					+ " remain:" + p + System.lineSeparator()
+					+ " triangles:" + triangles);
+			return List.of();
 		}
 
 		return triangles;
 	}
 
-	private boolean crossesPolygonEdge(final Segment e, final Polygon p, final int i0, final int i1, final double eps) {
+	private boolean crossesPolygonEdge(final Polygon p,
+			final Segment e0, final Segment e1, final Segment e,
+			final int i0, final int i1, final int i2,
+			final double eps) {
+
+		if (GeomUtil.isOverlap(e0, e1, eps)) {
+			return false;
+		}
+
+//		if ((e1.length() < eps)) {
+//			return false;
+//		}
+
 		for (int j = 0; j < p.verticesCount(); j++) {
 			if (j == i0 || j == i1) {
 				continue;

--- a/src/main/java/oripa/geom/TwoEarTriangulation.java
+++ b/src/main/java/oripa/geom/TwoEarTriangulation.java
@@ -1,0 +1,129 @@
+/**
+ * ORIPA - Origami Pattern Editor
+ * Copyright (C) 2013-     ORIPA OSS Project  https://github.com/oripa/oripa
+ * Copyright (C) 2005-2009 Jun Mitani         http://mitani.cs.tsukuba.ac.jp/
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package oripa.geom;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author OUCHI Koji
+ *
+ */
+public class TwoEarTriangulation {
+	private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	/**
+	 * returns list of triangles. empty if failed.
+	 *
+	 * @param polygon
+	 * @param eps
+	 * @return
+	 */
+	public List<Polygon> triangulate(final Polygon polygon, final double eps) {
+
+		var triangles = new ArrayList<Polygon>();
+
+		var p = polygon;
+		for (int k = 0; k < polygon.verticesCount() - 2; k++) {
+			if (p.verticesCount() == 3) {
+				break;
+			}
+
+			for (int i = 0; i < p.verticesCount(); i++) {
+				int i0 = i;
+				int i1 = (i + 1) % p.verticesCount();
+				int i2 = (i + 2) % p.verticesCount();
+
+				logger.trace("try {},{},{}", i0, i1, i2);
+
+				var v0 = p.getVertex(i0);
+				var v1 = p.getVertex(i1);
+				var v2 = p.getVertex(i2);
+
+				// center angle should not be larger than or equal to 180
+				// degrees.
+				if (!GeomUtil.isStrictlyCCW(v0, v1, v2)) {
+					logger.trace("reflex vertex: {}", v1);
+					logger.trace(System.lineSeparator()
+							+ " remain:" + p + System.lineSeparator()
+							+ triangles.size() + " triangles:" + triangles);
+					continue;
+				}
+				var e = new Segment(v0, v2);
+				if (!crossesPolygonEdge(e, p, i0, i1, eps)) {
+					p = p.removeVertex(i1);
+					var triangle = new Polygon(List.of(v0, v1, v2));
+					triangles.add(triangle);
+					break;
+				}
+
+			}
+		}
+
+		if (p.verticesCount() != 3) {
+			logger.trace("failed: fewer cuts " + polygon.verticesCount()
+					+ "->" + p.verticesCount() + System.lineSeparator()
+					+ " polygon:" + polygon + System.lineSeparator()
+					+ " remain:" + p + System.lineSeparator()
+					+ " triangles:" + triangles);
+			return List.of();
+		}
+
+		triangles.add(p);
+
+		if (triangles.size() != polygon.verticesCount() - 2) {
+			throw new AssertionError("Wrong implementation!: #triangle should be " + (polygon.verticesCount() - 2)
+					+ " but is " + triangles.size());
+		}
+
+		return triangles;
+	}
+
+	private boolean crossesPolygonEdge(final Segment e, final Polygon p, final int i0, final int i1, final double eps) {
+		for (int j = 0; j < p.verticesCount(); j++) {
+			if (j == i0 || j == i1) {
+				continue;
+			}
+
+			var e_j = p.getEdge(j);
+
+			if (e.equals(e_j, eps)) {
+				return true;
+			}
+
+			var crossOpt = GeomUtil.getCrossPoint(e, e_j);
+			// crosses
+			if (crossOpt.isPresent()) {
+				// cross point is the endpoint of e
+				if (crossOpt.filter(cross -> e.pointStream().anyMatch(v -> v.equals(cross, eps))).isPresent()) {
+					// cross point is the angle of the triangle
+					continue;
+				}
+				return true;
+			} else if (GeomUtil.isOverlap(e, e_j, eps)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/oripa/gui/presenter/foldability/FoldabilityGraphicDrawer.java
+++ b/src/main/java/oripa/gui/presenter/foldability/FoldabilityGraphicDrawer.java
@@ -49,8 +49,12 @@ public class FoldabilityGraphicDrawer {
 
 			var id = face.getFaceID();
 			if (id >= 0) {
-				var centroid = face.getCentroidBeforeFolding();
-				drawer.drawString(Integer.toString(id), (float) centroid.getX(), (float) centroid.getY(), scale);
+				var centroidOpt = face.getCentroidBeforeFolding();
+				centroidOpt.ifPresent(centroid -> drawer
+						.drawString(Integer.toString(id),
+								(float) centroid.getX(),
+								(float) centroid.getY(),
+								scale));
 			}
 		}
 

--- a/src/main/java/oripa/gui/presenter/main/logic/ModelComputationFacade.java
+++ b/src/main/java/oripa/gui/presenter/main/logic/ModelComputationFacade.java
@@ -191,7 +191,7 @@ public class ModelComputationFacade {
 		var foldResults = origamiModels.stream()
 				.map(model -> folderFactory
 						.create(model.getModelType())
-						.fold(model, model.getPaperSize() * eps * 10,
+						.fold(model, model.getPaperSize() * eps,
 								type.toEstimationType()))
 				.toList();
 

--- a/src/main/java/oripa/gui/presenter/main/logic/ModelComputationFacade.java
+++ b/src/main/java/oripa/gui/presenter/main/logic/ModelComputationFacade.java
@@ -189,7 +189,10 @@ public class ModelComputationFacade {
 			final ComputationType type) {
 
 		var foldResults = origamiModels.stream()
-				.map(model -> folderFactory.create(model.getModelType()).fold(model, eps, type.toEstimationType()))
+				.map(model -> folderFactory
+						.create(model.getModelType())
+						.fold(model, model.getPaperSize() * eps * 10,
+								type.toEstimationType()))
 				.toList();
 
 		var foldedModels = foldResults.stream().map(Folder.Result::foldedModel).toList();

--- a/src/main/java/oripa/gui/presenter/main/logic/SubFramePresentationLogic.java
+++ b/src/main/java/oripa/gui/presenter/main/logic/SubFramePresentationLogic.java
@@ -108,9 +108,14 @@ public class SubFramePresentationLogic {
 
 		var origamiModels = modelComputation.buildOrigamiModels(creasePattern);
 
-		computationResult = modelComputation.computeModels(
-				origamiModels,
-				getComputationType());
+		try {
+			computationResult = modelComputation.computeModels(
+					origamiModels,
+					getComputationType());
+		} catch (Exception e) {
+			computationResult = null;
+			throw e;
+		}
 	}
 
 	private ComputationType getComputationType() {

--- a/src/main/java/oripa/persistence/doc/exporter/ExporterFOLD.java
+++ b/src/main/java/oripa/persistence/doc/exporter/ExporterFOLD.java
@@ -27,10 +27,10 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.GsonBuilder;
 
+import oripa.domain.cptool.PointsMerger;
 import oripa.persistence.doc.Doc;
 import oripa.persistence.foldformat.CreasePatternElementConverter;
 import oripa.persistence.foldformat.CreasePatternFOLDFormat;
-import oripa.persistence.foldformat.PointsMerger;
 
 /**
  * @author OUCHI Koji

--- a/src/main/java/oripa/persistence/foldformat/FoldedModelElementConverter.java
+++ b/src/main/java/oripa/persistence/foldformat/FoldedModelElementConverter.java
@@ -194,7 +194,7 @@ public class FoldedModelElementConverter {
 				face.getHalfedge(j).setEdge(edges.get(edgeIndex));
 			}
 
-			if (!GeomUtil.isCCW(
+			if (!GeomUtil.isStrictlyCCW(
 					face.getHalfedge(0).getPosition(),
 					face.getHalfedge(1).getPosition(),
 					face.getHalfedge(2).getPosition())) {

--- a/src/main/java/oripa/renderer/estimation/FaceFactory.java
+++ b/src/main/java/oripa/renderer/estimation/FaceFactory.java
@@ -69,6 +69,8 @@ class FaceFactory {
 			convertedFace.addHalfedge(he);
 		}
 
+		convertedFace.makeHalfedgeLoop();
+
 		return convertedFace;
 	}
 

--- a/src/main/java/oripa/renderer/estimation/FaceFactory.java
+++ b/src/main/java/oripa/renderer/estimation/FaceFactory.java
@@ -69,6 +69,9 @@ class FaceFactory {
 			convertedFace.addHalfedge(he);
 		}
 
+		if (!face.isFaceFront()) {
+			convertedFace.invertFaceFront();
+		}
 		convertedFace.makeHalfedgeLoop();
 
 		return convertedFace;

--- a/src/main/java/oripa/util/MathUtil.java
+++ b/src/main/java/oripa/util/MathUtil.java
@@ -18,6 +18,7 @@
  */
 package oripa.util;
 
+import java.util.List;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -128,6 +129,66 @@ public class MathUtil {
 		}
 
 		throw new IllegalStateException("approximation failed.");
+	}
+
+	public static boolean canCauseDigitLoss(final double a, final double b, final boolean isAddition,
+			final double eps) {
+
+		var m = Math.abs(Math.max(a, b));
+		if (Math.abs(Math.abs(a) / m - Math.abs(b) / m) > eps) {
+			return false;
+		}
+
+		if (a == 0 || b == 0) {
+			return false;
+		}
+
+		if (isAddition) {
+			return Math.signum(a) != Math.signum(b);
+		} else {
+			return Math.signum(a) == Math.signum(b);
+		}
+	}
+
+	/**
+	 * from https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+	 *
+	 * @param values
+	 * @return
+	 */
+	public static double preciseSum(final List<Double> values) {
+		// Prepare the accumulator.
+		double sum = 0.0;
+		// A running compensation for lost low-order bits.
+		double c = 0.0;
+		// The array input has elements indexed input[1] to input[input.length].
+		for (double v : values) {
+			// c is zero the first time around.
+			double y = v - c;
+			// Alas, sum is big, y small, so low-order digits of y are lost.
+			double t = sum + y;
+			// (t - sum) cancels the high-order part of y;
+			// subtracting y recovers negative (low part of y)
+			double b = t - sum;
+			c = b - y;
+			// Algebraically, c should always be zero. Beware
+			// overly-aggressive optimizing compilers!
+			sum = t;
+			// Next time around, the lost low part will be added to y in a fresh
+			// attempt.
+		}
+		return sum;
+	}
+
+	public static double preciseSum(final double a, final double b) {
+		return preciseSum(List.of(a, b));
+	}
+
+	public static double preciseAddWithFactor(final double ra, final double a, final double rb, final double b) {
+		// there may be some other trick to reduce errors but I couldn't figure
+		// out it...
+
+		return preciseSum(ra * a, rb * b);
 	}
 
 }

--- a/src/main/java/oripa/vecmath/Vector2d.java
+++ b/src/main/java/oripa/vecmath/Vector2d.java
@@ -20,8 +20,10 @@ package oripa.vecmath;
 
 import static java.lang.Math.*;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import oripa.util.MathUtil;
 
@@ -51,6 +53,21 @@ public class Vector2d {
 	public Vector2d(final double x, final double y) {
 		this.x = x;
 		this.y = y;
+	}
+
+	public static <T extends Vector2d> Optional<T> findNearest(final T target, final Collection<T> vertices) {
+		T nearest = null;
+		for (var v : vertices) {
+			if (nearest == null) {
+				nearest = v;
+				continue;
+			}
+			if (nearest.distance(target) > v.distance(target)) {
+				nearest = v;
+			}
+		}
+
+		return Optional.ofNullable(nearest);
 	}
 
 	public double[] toArray() {

--- a/src/main/java/oripa/vecmath/Vector2d.java
+++ b/src/main/java/oripa/vecmath/Vector2d.java
@@ -155,6 +155,10 @@ public class Vector2d {
 		return angle < MathUtil.angleRadianEps() || angle > PI - MathUtil.angleRadianEps();
 	}
 
+	public double crossProductZ(final Vector2d v) {
+		return x * v.y - y * v.x;
+	}
+
 	@Override
 	public boolean equals(final Object o) {
 		if (o instanceof Vector2d v) {

--- a/src/test/java/oripa/domain/cptool/LineMirrorTest.java
+++ b/src/test/java/oripa/domain/cptool/LineMirrorTest.java
@@ -51,11 +51,11 @@ class LineMirrorTest {
 
 		assertEquals(2, mirroredLines.size());
 
-		var mirroredLine = new OriLine(100, 0, 90, 0, Type.MOUNTAIN);
-		assertTrue(mirroredLines.contains(mirroredLine));
+		var mirroredLine1 = new OriLine(100, 0, 90, 0, Type.MOUNTAIN);
+		assertTrue(mirroredLines.stream().anyMatch(l -> l.equals(mirroredLine1, 1e-8)));
 
-		mirroredLine = new OriLine(80, 20, 80, 0, Type.VALLEY);
-		assertTrue(mirroredLines.contains(mirroredLine));
+		var mirroredLine2 = new OriLine(80, 20, 80, 0, Type.VALLEY);
+		assertTrue(mirroredLines.stream().anyMatch(l -> l.equals(mirroredLine2, 1e-8)));
 	}
 
 }

--- a/src/test/java/oripa/domain/fold/halfedge/OriFaceTest.java
+++ b/src/test/java/oripa/domain/fold/halfedge/OriFaceTest.java
@@ -50,6 +50,8 @@ class OriFaceTest {
 		face.addHalfedge(he1);
 		face.addHalfedge(he2);
 		face.addHalfedge(he3);
+
+		face.makeHalfedgeLoop();
 	}
 
 	private OriHalfedge createHalfEdgeSpy(final double x, final double y, final OriFace face) {

--- a/src/test/java/oripa/domain/fold/subface/FacesToCreasePatternConverterTest.java
+++ b/src/test/java/oripa/domain/fold/subface/FacesToCreasePatternConverterTest.java
@@ -30,7 +30,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import oripa.domain.cptool.ElementRemover;
 import oripa.domain.cptool.LineAdder;
+import oripa.domain.cptool.PointsMerger;
 import oripa.domain.creasepattern.CreasePattern;
 import oripa.domain.creasepattern.CreasePatternFactory;
 import oripa.domain.fold.subface.test.OriFaceFactoryForTest;
@@ -47,28 +49,33 @@ class FacesToCreasePatternConverterTest {
 	private CreasePatternFactory cpFactory;
 	@Mock
 	private LineAdder adder;
+	@Mock
+	private ElementRemover remover;
+	@Mock
+	private PointsMerger pointMerger;
 
 	@Mock
 	private CreasePattern creasePattern;
 
 	private static final double POINT_EPS = 1e-7;
 
-	/**
-	 * Test method for
-	 * {@link oripa.domain.fold.subface.FacesToCreasePatternConverter#convertToCreasePattern(java.util.List)}.
-	 */
 	@Test
 	void testConvertToCreasePattern() {
 		var face1 = OriFaceFactoryForTest.create10PxSquareMock(0, 0);
 		var face2 = OriFaceFactoryForTest.create10PxSquareMock(10, 0);
+
 		var faces = List.of(face1, face2);
 
 		when(cpFactory.createCreasePattern(anyCollection())).thenReturn(creasePattern);
+
+		when(pointMerger.mergeClosePoints(anyCollection(), anyDouble())).thenReturn(creasePattern);
 
 		var converted = converter.convertToCreasePattern(faces, POINT_EPS);
 		assertSame(creasePattern, converted);
 
 		// tried to convert all faces?
 		verify(adder, times(faces.size())).addAll(any(), anyCollection(), anyDouble());
+
+		verify(remover).removeMeaninglessVertices(creasePattern, POINT_EPS);
 	}
 }

--- a/src/test/java/oripa/domain/fold/subface/ParentFacesCollectorTest.java
+++ b/src/test/java/oripa/domain/fold/subface/ParentFacesCollectorTest.java
@@ -42,8 +42,6 @@ class ParentFacesCollectorTest {
 	private ParentFacesCollector collector;
 
 	/**
-	 * Test method for
-	 * {@link oripa.domain.fold.subface.ParentFacesCollector#collect(java.util.List, oripa.domain.fold.subface.SubFace, double)}.
 	 */
 	@Test
 	void testCollect() {
@@ -56,7 +54,7 @@ class ParentFacesCollectorTest {
 
 		var subface = mock(SubFace.class);
 		var innerPoint = new Vector2d(8, 8);
-		when(subface.getInnerPoint()).thenReturn(innerPoint);
+		when(subface.getInnerPoints(1e-6)).thenReturn(List.of(innerPoint));
 
 		when(face1.includesExclusively(eq(innerPoint), anyDouble())).thenReturn(true);
 		when(face2.includesExclusively(eq(innerPoint), anyDouble())).thenReturn(false);

--- a/src/test/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverterTest.java
+++ b/src/test/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverterTest.java
@@ -19,7 +19,9 @@
 package oripa.domain.fold.subface;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import oripa.domain.fold.halfedge.OriVertex;
 import oripa.domain.fold.subface.test.OriFaceFactoryForTest;
 
 /**
@@ -47,9 +50,15 @@ class SplitFacesToSubFacesConverterTest {
 		var splitFace1 = OriFaceFactoryForTest.create10PxSquareMock(0, 0);
 		var splitFace2 = OriFaceFactoryForTest.create10PxSquareMock(10, 0);
 
+		when(splitFace1.remove180degreeVertices()).thenReturn(splitFace1);
+		when(splitFace2.remove180degreeVertices()).thenReturn(splitFace2);
+
+		OriVertex vertex = mock();
+		Collection<OriVertex> vertices = List.of(vertex);
+
 		var splitFaces = List.of(splitFace1, splitFace2);
 
-		var subFaces = converter.convertToSubFaces(splitFaces, 1e-6);
+		var subFaces = converter.convertToSubFaces(splitFaces, vertices, 1e-6);
 
 		for (int i = 0; i < subFaces.size(); i++) {
 			assertSame(splitFaces.get(i), subFaces.get(i).getOutline());

--- a/src/test/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverterTest.java
+++ b/src/test/java/oripa/domain/fold/subface/SplitFacesToSubFacesConverterTest.java
@@ -19,6 +19,7 @@
 package oripa.domain.fold.subface;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;
@@ -51,7 +52,12 @@ class SplitFacesToSubFacesConverterTest {
 		var splitFace2 = OriFaceFactoryForTest.create10PxSquareMock(10, 0);
 
 		when(splitFace1.remove180degreeVertices()).thenReturn(splitFace1);
+		when(splitFace1.removeDuplicatedVertices(anyDouble())).thenReturn(splitFace1);
+		when(splitFace1.halfedgeCount()).thenReturn(4);
+
 		when(splitFace2.remove180degreeVertices()).thenReturn(splitFace2);
+		when(splitFace2.removeDuplicatedVertices(anyDouble())).thenReturn(splitFace2);
+		when(splitFace2.halfedgeCount()).thenReturn(4);
 
 		OriVertex vertex = mock();
 		Collection<OriVertex> vertices = List.of(vertex);

--- a/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
+++ b/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import oripa.domain.creasepattern.CreasePattern;
 import oripa.domain.fold.halfedge.OriFace;
+import oripa.domain.fold.halfedge.OriVertex;
 import oripa.domain.fold.halfedge.OrigamiModel;
 import oripa.domain.fold.halfedge.OrigamiModelFactory;
 
@@ -76,19 +77,24 @@ class SubFacesFactoryTest {
 		when(modelFactory.buildOrigamiForSubfaces(cp, PAPER_SIZE, EPS)).thenReturn(model);
 
 		var splitFaces = new ArrayList<OriFace>();
-		when(model.getFaces()).thenReturn(splitFaces);
 
 		var sub1 = createSubFaceMock();
 		var sub2 = createSubFaceMock();
 
+		OriVertex vertex1 = mock();
+		List<OriVertex> vertices = List.of(vertex1);
+
+		when(model.getFaces()).thenReturn(splitFaces);
+		when(model.getVertices()).thenReturn(vertices);
+
 		var conversionSubfaces = List.of(sub1, sub2);
-		when(facesToSubFacesConverter.convertToSubFaces(splitFaces, EPS)).thenReturn(conversionSubfaces);
+		when(facesToSubFacesConverter.convertToSubFaces(splitFaces, vertices, EPS)).thenReturn(conversionSubfaces);
 
 		var subfaces = subFacesFactory.createSubFaces(inputFaces, PAPER_SIZE, EPS);
 
 		verify(facesToCPConverter).convertToCreasePattern(inputFaces, EPS);
 		verify(modelFactory).buildOrigamiForSubfaces(cp, PAPER_SIZE, EPS);
-		verify(facesToSubFacesConverter).convertToSubFaces(splitFaces, EPS);
+		verify(facesToSubFacesConverter).convertToSubFaces(splitFaces, vertices, EPS);
 
 		assertEquals(2, subfaces.size());
 

--- a/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
+++ b/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
@@ -80,41 +80,21 @@ class SubFacesFactoryTest {
 
 		var sub1 = createSubFaceMock();
 		var sub2 = createSubFaceMock();
-		var sub3 = createSubFaceMock();
 
-		lenient().when(sub1.isSame(sub2)).thenReturn(true);
-		lenient().when(sub1.isSame(sub3)).thenReturn(false);
+		var conversionSubfaces = List.of(sub1, sub2);
+		when(facesToSubFacesConverter.convertToSubFaces(splitFaces, EPS)).thenReturn(conversionSubfaces);
 
-		lenient().when(sub2.isSame(sub1)).thenReturn(true);
-		lenient().when(sub2.isSame(sub3)).thenReturn(false);
-
-		lenient().when(sub3.isSame(sub1)).thenReturn(false);
-		lenient().when(sub3.isSame(sub2)).thenReturn(false);
-
-		var subFacesWithDuplication = List.of(sub1, sub2, sub3);
-		when(facesToSubFacesConverter.convertToSubFaces(splitFaces, EPS)).thenReturn(subFacesWithDuplication);
-
-		when(parentCollector.collect(inputFaces, sub1, EPS))
-				.thenReturn(List.of(face1, face2));
-		when(parentCollector.collect(inputFaces, sub2, EPS))
-				.thenReturn(List.of(face2, face1));
-		when(parentCollector.collect(inputFaces, sub3, EPS))
-				.thenReturn(List.of(face1, face2, face3));
-
-		var subFaces = subFacesFactory.createSubFaces(inputFaces, PAPER_SIZE, EPS);
+		var subfaces = subFacesFactory.createSubFaces(inputFaces, PAPER_SIZE, EPS);
 
 		verify(facesToCPConverter).convertToCreasePattern(inputFaces, EPS);
 		verify(modelFactory).buildOrigamiForSubfaces(cp, PAPER_SIZE, EPS);
 		verify(facesToSubFacesConverter).convertToSubFaces(splitFaces, EPS);
-		verify(parentCollector).collect(inputFaces, sub1, EPS);
-		verify(parentCollector).collect(inputFaces, sub2, EPS);
-		verify(parentCollector).collect(inputFaces, sub3, EPS);
 
-		assertEquals(2, subFaces.size());
+		assertEquals(2, subfaces.size());
 
 		// subface should have distinct list of parent faces.
-		assertTrue(subFaces.contains(sub1));
-		assertTrue(subFaces.contains(sub3));
+		assertTrue(subfaces.contains(sub1));
+		assertTrue(subfaces.contains(sub2));
 	}
 
 	private SubFace createSubFaceMock() {

--- a/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
+++ b/src/test/java/oripa/domain/fold/subface/SubFacesFactoryTest.java
@@ -92,7 +92,7 @@ class SubFacesFactoryTest {
 		lenient().when(sub3.isSame(sub2)).thenReturn(false);
 
 		var subFacesWithDuplication = List.of(sub1, sub2, sub3);
-		when(facesToSubFacesConverter.convertToSubFaces(splitFaces)).thenReturn(subFacesWithDuplication);
+		when(facesToSubFacesConverter.convertToSubFaces(splitFaces, EPS)).thenReturn(subFacesWithDuplication);
 
 		when(parentCollector.collect(inputFaces, sub1, EPS))
 				.thenReturn(List.of(face1, face2));
@@ -105,7 +105,7 @@ class SubFacesFactoryTest {
 
 		verify(facesToCPConverter).convertToCreasePattern(inputFaces, EPS);
 		verify(modelFactory).buildOrigamiForSubfaces(cp, PAPER_SIZE, EPS);
-		verify(facesToSubFacesConverter).convertToSubFaces(splitFaces);
+		verify(facesToSubFacesConverter).convertToSubFaces(splitFaces, EPS);
 		verify(parentCollector).collect(inputFaces, sub1, EPS);
 		verify(parentCollector).collect(inputFaces, sub2, EPS);
 		verify(parentCollector).collect(inputFaces, sub3, EPS);

--- a/src/test/java/oripa/domain/fold/subface/test/OriFaceFactoryForTest.java
+++ b/src/test/java/oripa/domain/fold/subface/test/OriFaceFactoryForTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.halfedge.OriHalfedge;
 import oripa.domain.fold.halfedge.OriVertex;
+import oripa.geom.Polygon;
 import oripa.vecmath.Vector2d;
 
 /**
@@ -73,6 +74,11 @@ public class OriFaceFactoryForTest {
 		var list = List.of(he1, he2, he3, he4);
 		lenient().when(face.halfedgeIterable()).thenReturn(list);
 		lenient().when(face.halfedgeStream()).thenAnswer(invocation -> list.stream());
+
+		lenient().when(face.toPolygon()).thenReturn(
+				new Polygon(List.of(new Vector2d(left, top), new Vector2d(right, top), new Vector2d(right, bottom),
+						new Vector2d(left, bottom))));
+
 		return face;
 	}
 

--- a/src/test/java/oripa/geom/GeomUtilTest.java
+++ b/src/test/java/oripa/geom/GeomUtilTest.java
@@ -22,6 +22,8 @@ package oripa.geom;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import oripa.vecmath.Vector2d;
 
@@ -55,5 +57,19 @@ class GeomUtilTest {
 
 		assertEquals(Math.sqrt(2) / 2, direction.getX(), 1e-8);
 		assertEquals(Math.sqrt(2) / 2, direction.getY(), 1e-8);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"1,1, 0,0, 2,0, 1,0",
+	})
+	void testGetNearestPointToSegment(final double px, final double py, final double sx, final double sy,
+			final double ex, final double ey, final double nx, final double ny) {
+		var p = new Vector2d(px, py);
+		var segment = new Segment(sx, sy, ex, ey);
+		var nearest = GeomUtil.getNearestPointToSegment(p, segment);
+
+		assertEquals(nx, nearest.getX(), 1e-8);
+		assertEquals(ny, nearest.getY(), 1e-8);
 	}
 }

--- a/src/test/java/oripa/geom/TwoEarTriangulationTest.java
+++ b/src/test/java/oripa/geom/TwoEarTriangulationTest.java
@@ -50,25 +50,80 @@ class TwoEarTriangulationTest {
 		}
 	}
 
-	@Test
-	void testPointsOnOneEdge() {
-		var polygon = new Polygon(List.of(
-				new Vector2d(0, 0),
-				new Vector2d(0, 1),
-				new Vector2d(0, 2),
-				new Vector2d(0, 3),
-				new Vector2d(0, 4),
-				new Vector2d(0, 5),
-				new Vector2d(-1, 5),
-				new Vector2d(-1, 4)));
-
-		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
-
-		assertEquals(6, triangles.size());
-		for (var t : triangles) {
-			assertEquals(3, t.verticesCount());
-		}
-
-	}
+//	@Test
+//	void testPointsOnOneEdge() {
+//		var polygon = new Polygon(List.of(
+//				new Vector2d(0, 0),
+//				new Vector2d(0, 1),
+//				new Vector2d(0, 2),
+//				new Vector2d(0, 3),
+//				new Vector2d(0, 4),
+//				new Vector2d(0, 5),
+//				new Vector2d(-1, 5),
+//				new Vector2d(-1, 4)));
+//
+//		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
+//
+//		assertEquals(6, triangles.size());
+//		for (var t : triangles) {
+//			assertEquals(3, t.verticesCount());
+//		}
+//
+//	}
+//
+//	@Test
+//	void testDuplecatedEdges() {
+//		var polygon = new Polygon(List.of(
+//				new Vector2d(0, 0),
+//				new Vector2d(1, 0),
+//				new Vector2d(1, 2),
+//				new Vector2d(1, 0)));
+//
+//		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
+//
+//		assertEquals(2, triangles.size());
+//		for (var t : triangles) {
+//			assertEquals(3, t.verticesCount());
+//		}
+//
+//	}
+//
+//	@Test
+//	void testOverlapEdges() {
+//		var polygon = new Polygon(List.of(
+//				new Vector2d(0, -1),
+//				new Vector2d(0, 0),
+//				new Vector2d(2, 0),
+//				new Vector2d(1, 0),
+//				new Vector2d(-1, 0)));
+//
+//		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
+//
+//		assertEquals(3, triangles.size());
+//		for (var t : triangles) {
+//			assertEquals(3, t.verticesCount());
+//		}
+//
+//	}
+//
+//	@Test
+//	void testDoubledEdgesAndZeroLengthEdges() {
+//		var polygon = new Polygon(List.of(
+//				new Vector2d(0, 0),
+//				new Vector2d(1, 0),
+//				new Vector2d(1, 1),
+//				new Vector2d(1, 1),
+//				new Vector2d(1, 0),
+//				new Vector2d(1, 0),
+//				new Vector2d(0, 0)));
+//
+//		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
+//
+//		assertEquals(5, triangles.size());
+//		for (var t : triangles) {
+//			assertEquals(3, t.verticesCount());
+//		}
+//
+//	}
 
 }

--- a/src/test/java/oripa/geom/TwoEarTriangulationTest.java
+++ b/src/test/java/oripa/geom/TwoEarTriangulationTest.java
@@ -16,44 +16,59 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package oripa.domain.fold.subface;
+package oripa.geom;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import oripa.domain.fold.subface.test.OriFaceFactoryForTest;
+import oripa.vecmath.Vector2d;
 
 /**
  * @author OUCHI Koji
  *
  */
-@ExtendWith(MockitoExtension.class)
-class SplitFacesToSubFacesConverterTest {
-	@InjectMocks
-	private SplitFacesToSubFacesConverter converter;
+class TwoEarTriangulationTest {
 
-	/**
-	 * Test method for
-	 * {@link oripa.domain.fold.subface.SplitFacesToSubFacesConverter#convertToSubFaces(java.util.List)}.
-	 */
 	@Test
-	void testConvertToSubFaces() {
-		var splitFace1 = OriFaceFactoryForTest.create10PxSquareMock(0, 0);
-		var splitFace2 = OriFaceFactoryForTest.create10PxSquareMock(10, 0);
+	void testNonConvex() {
+		var polygon = new Polygon(List.of(
+				new Vector2d(0, 0),
+				new Vector2d(2, 0),
+				new Vector2d(2, 2),
+				new Vector2d(1, 2),
+				new Vector2d(1, 1),
+				new Vector2d(0, 1)));
 
-		var splitFaces = List.of(splitFace1, splitFace2);
+		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
 
-		var subFaces = converter.convertToSubFaces(splitFaces, 1e-6);
-
-		for (int i = 0; i < subFaces.size(); i++) {
-			assertSame(splitFaces.get(i), subFaces.get(i).getOutline());
+		assertEquals(4, triangles.size());
+		for (var t : triangles) {
+			assertEquals(3, t.verticesCount());
 		}
+	}
+
+	@Test
+	void testPointsOnOneEdge() {
+		var polygon = new Polygon(List.of(
+				new Vector2d(0, 0),
+				new Vector2d(0, 1),
+				new Vector2d(0, 2),
+				new Vector2d(0, 3),
+				new Vector2d(0, 4),
+				new Vector2d(0, 5),
+				new Vector2d(-1, 5),
+				new Vector2d(-1, 4)));
+
+		var triangles = new TwoEarTriangulation().triangulate(polygon, 1e-6);
+
+		assertEquals(6, triangles.size());
+		for (var t : triangles) {
+			assertEquals(3, t.verticesCount());
+		}
+
 	}
 
 }

--- a/src/test/java/oripa/persistence/foldformat/GeometryTest.java
+++ b/src/test/java/oripa/persistence/foldformat/GeometryTest.java
@@ -18,7 +18,7 @@
  */
 package oripa.persistence.foldformat;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 

--- a/src/test/java/oripa/util/MathUtilTest.java
+++ b/src/test/java/oripa/util/MathUtilTest.java
@@ -20,6 +20,7 @@ package oripa.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,17 @@ class MathUtilTest {
 		var xAnswer = MathUtil.newtonMethod(f, 2, 1e-4, 1e-6);
 
 		assertEquals(Math.pow(2, 1.0 / 3), xAnswer, 1e-6);
+	}
+
+	@Test
+	void testPreciseSum() {
+		var values = new ArrayList<Double>();
+		for (int i = 0; i < 10; i++) {
+			values.add(0.1);
+		}
+
+		var sum = MathUtil.preciseSum(values);
+		assertEquals(1, sum);
 	}
 
 }

--- a/src/test/java/oripa/vecmath/Matrix2dTest.java
+++ b/src/test/java/oripa/vecmath/Matrix2dTest.java
@@ -18,8 +18,8 @@ class Matrix2dTest {
 		Vector2d result = m.product(v);
 
 		// then
-		assertEquals(17, result.getX());
-		assertEquals(39, result.getY());
+		assertEquals(17.0, result.getX(), 1e-8);
+		assertEquals(39, result.getY(), 1e-8);
 	}
 
 	@Test

--- a/src/test/java/oripa/vecmath/Vector2dTest.java
+++ b/src/test/java/oripa/vecmath/Vector2dTest.java
@@ -18,7 +18,9 @@
  */
 package oripa.vecmath;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,7 +49,7 @@ class Vector2dTest {
 			"1, 0,   0, 1,   0",
 			"1, 2,   2, 1,   4"
 	})
-	void testDotProduct(double x1, double y1, double x2, double y2, double expected) {
+	void testDotProduct(final double x1, final double y1, final double x2, final double y2, final double expected) {
 		var v0 = new Vector2d(x1, y1);
 		var v1 = new Vector2d(x2, y2);
 
@@ -61,7 +63,8 @@ class Vector2dTest {
 			"0.70710678, 0.70710678,   45,  0, 1",
 			"0, 1,   45, -0.70710678, 0.70710678",
 	})
-	void testRotate(double x, double y, double angleDegrees, double expectedX, double expectedY) {
+	void testRotate(final double x, final double y, final double angleDegrees, final double expectedX,
+			final double expectedY) {
 		var v = new Vector2d(x, y).rotate(Math.toRadians(angleDegrees));
 
 		assertEquals(expectedX, v.getX(), 1e-8);
@@ -76,7 +79,8 @@ class Vector2dTest {
 			"1, 0,   0.70710678, 0.70710678,   45",
 			"0.8660254038, 0.5,   0.5, 0.8660254038,   30",
 	})
-	void testAngle(double x1, double y1, double x2, double y2, double expectedAngleDegrees) {
+	void testAngle(final double x1, final double y1, final double x2, final double y2,
+			final double expectedAngleDegrees) {
 		var angle1 = new Vector2d(x1, y1).angle(new Vector2d(x2, y2));
 		var angle2 = new Vector2d(x2, y2).angle(new Vector2d(x1, y1));
 
@@ -91,10 +95,25 @@ class Vector2dTest {
 			"0.70710678, 0.70710678,   45",
 			"0.8660254038, 0.5,   30",
 	})
-	void testOwnAngle(double x, double y, double expectedAngleDegrees) {
+	void testOwnAngle(final double x, final double y, final double expectedAngleDegrees) {
 		var angle = new Vector2d(x, y).ownAngle();
 
 		assertEquals(expectedAngleDegrees, Math.toDegrees(angle), 1e-8);
+	}
+
+	@Test
+	void testFindNearest() {
+		var p = new Vector2d(1, 1);
+
+		var neighbors = List.of(
+				new Vector2d(1, 0),
+				new Vector2d(0, 1),
+				new Vector2d(1, 0.5),
+				new Vector2d(0.5, 0.5));
+
+		var nearest = Vector2d.findNearest(p, neighbors);
+
+		assertEquals(neighbors.get(2), nearest.get());
 	}
 
 }


### PR DESCRIPTION
Using centroid fails if faces are not convex.
Even the faces are convex, there is a case that the centroid is not on the other face.

In this implementation, we triangulate the faces and test whether one of the triangles includes some of the other's triangle centroids.
I believe still there is a case to fail but much improved the layer order estimation.