### PR TITLE
Use subface to check transitivity.

### DIFF
--- a/src/main/java/oripa/domain/fold/condfac/RelationPathEnumerator.java
+++ b/src/main/java/oripa/domain/fold/condfac/RelationPathEnumerator.java
@@ -1,0 +1,127 @@
+/**
+ * ORIPA - Origami Pattern Editor
+ * Copyright (C) 2013-     ORIPA OSS Project  https://github.com/oripa/oripa
+ * Copyright (C) 2005-2009 Jun Mitani         http://mitani.cs.tsukuba.ac.jp/
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package oripa.domain.fold.condfac;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oripa.domain.fold.origeom.OverlapRelation;
+import oripa.util.Matrices;
+
+/**
+ * Floyd-Warshall algorithm. for indices i and j (i < j) on the obtained path
+ * hold isUpper(path[i], path[j]) or isUndefined(path[i], path[j]).
+ *
+ * @author OUCHI Koji
+ *
+ */
+public class RelationPathEnumerator {
+	private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private int faceCount;
+
+	private int infinity() {
+		return faceCount * 2;
+	}
+
+	private int[][] distance;
+	private int[][] prevIndices;
+
+	public void findPaths(final OverlapRelation overlapRelation) {
+		faceCount = overlapRelation.getSize();
+
+		distance = new int[faceCount][faceCount];
+		prevIndices = new int[faceCount][faceCount];
+
+		for (int i = 0; i < faceCount; i++) {
+			for (int j = 0; j < faceCount; j++) {
+				if (overlapRelation.isUpper(i, j) || overlapRelation.isUndefined(i, j)) {
+					distance[i][j] = 1;
+					prevIndices[i][j] = i;
+				} else {
+					distance[i][j] = infinity();
+					prevIndices[i][j] = -1;
+				}
+			}
+		}
+
+		for (int i = 0; i < faceCount; i++) {
+			distance[i][i] = 0;
+			prevIndices[i][i] = i;
+		}
+
+		for (int k = 0; k < faceCount; k++) {
+			for (int i = 0; i < faceCount; i++) {
+				for (int j = 0; j < faceCount; j++) {
+					if (distance[i][j] > distance[i][k] + distance[k][j]) {
+						distance[i][j] = distance[i][k] + distance[k][j];
+						prevIndices[i][j] = prevIndices[k][j];
+					}
+				}
+
+			}
+		}
+
+		logger.debug(Matrices.toString(distance));
+	}
+
+	public List<Integer> getPath(final int i, final int j) {
+		if (prevIndices[i][j] == -1) {
+			return List.of();
+		}
+		var path = new LinkedList<Integer>();
+		path.add(j);
+
+		int v = j;
+		while (v != i) {
+			v = prevIndices[i][v];
+			path.addFirst(v);
+		}
+
+		return new ArrayList<>(path);
+	}
+
+	public boolean isOnCycle(final int i, final int j) {
+		if (distance[i][j] < infinity() && distance[j][i] < infinity()) {
+
+			if (distance[i][j] + distance[j][i] <= 2) {
+				return false;
+			}
+
+			return true;
+		}
+		return false;
+	}
+
+	public List<Integer> getCycle(final int i, final int j) {
+		if (distance[i][j] < infinity() && distance[j][i] < infinity()) {
+			var path = getPath(i, j);
+			path.removeLast();
+			path.addAll(getPath(j, i));
+			path.removeLast();
+			return path;
+		}
+		return List.of();
+	}
+}

--- a/src/main/java/oripa/domain/fold/halfedge/OriFacesFactory.java
+++ b/src/main/java/oripa/domain/fold/halfedge/OriFacesFactory.java
@@ -80,6 +80,11 @@ public class OriFacesFactory {
 
 		logger.debug("#face = {}", faces.size());
 
+		int id = 0;
+		for (var face : faces) {
+			face.setFaceID(id++);
+		}
+
 		return valid;
 	}
 

--- a/src/main/java/oripa/domain/fold/subface/SubFace.java
+++ b/src/main/java/oripa/domain/fold/subface/SubFace.java
@@ -34,15 +34,11 @@ import oripa.domain.fold.halfedge.OriFace;
 import oripa.domain.fold.origeom.OverlapRelation;
 import oripa.domain.fold.stackcond.StackConditionOf3Faces;
 import oripa.domain.fold.stackcond.StackConditionOf4Faces;
-import oripa.geom.Polygon;
-import oripa.geom.TwoEarTriangulation;
 import oripa.vecmath.Vector2d;
 
 public class SubFace {
 
 	private final OriFace outline;
-
-	private final List<Polygon> outlineTriangulation;
 
 	/**
 	 * faces containing this subface.
@@ -71,7 +67,6 @@ public class SubFace {
 	 */
 	public SubFace(final OriFace outline, final double eps) {
 		this.outline = outline;
-		this.outlineTriangulation = new TwoEarTriangulation().triangulate(outline.toPolygon(eps), eps);
 	}
 
 	/**
@@ -290,6 +285,10 @@ public class SubFace {
 
 	public OriFace getParentFace(final int index) {
 		return parentFaces.get(index);
+	}
+
+	public Set<Integer> getParentFaceIndices() {
+		return Collections.unmodifiableSet(parentFaceIndices);
 	}
 
 	public boolean isParentFace(final OriFace face) {

--- a/src/main/java/oripa/util/BitArray.java
+++ b/src/main/java/oripa/util/BitArray.java
@@ -45,6 +45,11 @@ public class BitArray {
 		Arrays.fill(blocks, 0);
 	}
 
+	public BitArray(final BitArray other) {
+		this(other.bitLength);
+		setAll(other);
+	}
+
 	public void setAll(final BitArray other) {
 		if (bitLength != other.bitLength) {
 			throw new IllegalArgumentException("bit length should be equal.");
@@ -191,5 +196,14 @@ public class BitArray {
 	@Override
 	public int hashCode() {
 		return Objects.hash(bitLength, blocks);
+	}
+
+	@Override
+	public String toString() {
+		return Arrays.stream(blocks)
+				.mapToObj(block -> "%8s".formatted(Integer.toHexString(block)).replace(' ', '0'))
+				.toList()
+				.reversed().stream()
+				.reduce("", String::concat);
 	}
 }

--- a/src/main/java/oripa/util/BitSet.java
+++ b/src/main/java/oripa/util/BitSet.java
@@ -18,8 +18,10 @@
  */
 package oripa.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -54,13 +56,20 @@ public class BitSet implements Set<Integer> {
 				index++;
 			}
 			usedCount++;
-			return index;
+
+			var result = index;
+			index++;
+			return result;
 		}
 
 	}
 
 	public BitSet(final int bitLength) {
 		bits = new BitArray(bitLength);
+	}
+
+	public BitSet(final BitSet other) {
+		bits = new BitArray(other.bits);
 	}
 
 	@Override
@@ -243,6 +252,15 @@ public class BitSet implements Set<Integer> {
 		}
 
 		return false;
+	}
+
+	public List<Integer> toList() {
+		var list = new ArrayList<Integer>();
+
+		for (var i : this) {
+			list.add(i);
+		}
+		return list;
 	}
 
 	@Override

--- a/src/test/java/oripa/util/BitArrayTest.java
+++ b/src/test/java/oripa/util/BitArrayTest.java
@@ -33,10 +33,25 @@ class BitArrayTest {
 		var bits = new BitArray(32);
 
 		bits.setOne(31);
+		assertEquals("80000000", bits.toString());
 		assertTrue(bits.get(31));
+		bits.setZero(31);
+		assertEquals("00000000", bits.toString());
 
 		bits.setOne(0);
 		assertTrue(bits.get(0));
+		assertEquals("00000001", bits.toString());
+
+	}
+
+	@Test
+	void test23BitsGetSet() {
+		var bits = new BitArray(23);
+
+		bits.setOne(22);
+		assertTrue(bits.get(22));
+		assertEquals("00400000", bits.toString());
+
 	}
 
 	@Test


### PR DESCRIPTION
#283 was wrong.

For parent faces of a subface that have order for every pair, we can sort them and check the sorting result is valid or not.
The sort might fail to detect wrong ordering but maybe it is enough for most cases. 